### PR TITLE
Make ar outputs deterministic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "alexcrichton/gcc-rs" }
 appveyor = { repository = "alexcrichton/gcc-rs" }
 
 [dependencies]
+ar = "0.3"
 rayon = { version = "0.8", optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
 
+extern crate ar;
 #[cfg(feature = "parallel")]
 extern crate rayon;
 
@@ -50,6 +51,7 @@ use std::fs;
 use std::path::{PathBuf, Path};
 use std::process::{Command, Stdio, Child};
 use std::io::{self, BufReader, BufRead, Read, Write};
+use std::str;
 use std::thread::{self, JoinHandle};
 
 // These modules are all glue to support reading the MSVC version from
@@ -975,14 +977,16 @@ impl Config {
                 })
                 .expect("Copying from {:?} to {:?} failed.");;
         } else {
+            let ar_dst = dst.with_file_name(format!("lib{}.a.tmp", lib_name));
             let ar = self.get_ar();
             let cmd = ar.file_name().unwrap().to_string_lossy();
             run(self.cmd(&ar)
                     .arg("crs")
-                    .arg(dst)
+                    .arg(&ar_dst)
                     .args(objects)
                     .args(&self.objects),
                 &cmd);
+            make_ar_deterministic(&ar_dst, dst).expect("Making static lib deterministic failed.");
         }
     }
 
@@ -1410,4 +1414,37 @@ fn command_add_output_file(cmd: &mut Command, dst: &Path, msvc: bool, is_asm: bo
     } else {
         cmd.arg("-o").arg(&dst);
     }
+}
+
+fn make_ar_deterministic(src: &Path, dst: &Path) -> io::Result<()> {
+    // ar adds a timestamp in the header which makes its output
+    // non-deterministic. In order to have deterministic builds, we'll
+    // overwrite this timestamp, user, and group with zeroes.
+    if !src.exists() { return Ok(()) }
+    {
+        let infile = fs::File::open(src)?;
+        let outfile = fs::File::create(dst)?;
+
+        let mut in_archive = ar::Archive::new(infile);
+        let mut out_archive = ar::Builder::new(outfile);
+
+        while let Some(entry) = in_archive.next_entry() {
+            let entry = entry?;
+            let mut header;
+            let mode;
+            {
+                let old_header = entry.header();
+                header = ar::Header::new(old_header.identifier().to_string(), old_header.size());
+                mode = old_header.mode();
+            }
+            header.set_mtime(0);
+            header.set_uid(0);
+            header.set_gid(0);
+            header.set_mode(mode);
+            out_archive.append(&header, entry)?;
+        }
+    }
+    fs::remove_file(src)?;
+
+    Ok(())
 }


### PR DESCRIPTION
ar entry headers include timestamps and uid/gid which are not deterministic outputs. While binutils added command line flags to zero these fields out to make deterministic builds possible, macOS ar does not have these. This PR makes all invocations of ar deterministic by rewriting the archive and zeroing out the appropriate fields.

The immediate benefit of doing this is that sccache (and potentially other future Rust compiler caches) will be able to cache crates that include static C libraries are part of their build process.