### PR TITLE
Use Thumb-2 as Android/armv7-a's default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1017,6 +1017,7 @@ impl Build {
                 // (specified in the android spec online)
                 if target.starts_with("armv7-linux-androideabi") {
                     cmd.args.push("-march=armv7-a".into());
+                    cmd.args.push("-mthumb".into());
                     cmd.args.push("-mfpu=vfpv3-d16".into());
                     cmd.args.push("-mfloat-abi=softfp".into());
                 }


### PR DESCRIPTION
Actually, gcc-es doesn't generate thumb2 option as default even if Android/armv7-a.

From https://developer.android.com/ndk/guides/standalone_toolchain.html#abi_compatibility

> We recommend using the -mthumb compiler flag to force the generation of 16-bit Thumb-2 instructions (Thumb-1 for armeabi). If omitted, the toolchain will emit 32-bit ARM instructions.

Since Android is mobile and embedded platform, so we should use -mthumb as android's default for footprint.