### PR TITLE
fix(flag_check): Send flag to MSVC telling it not to link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,13 @@ impl Build {
         let compiler = cfg.try_get_compiler()?;
         let mut cmd = compiler.to_command();
         command_add_output_file(&mut cmd, &obj, target.contains("msvc"), false);
+
+        // We need to explicitly tell msvc not to link and create an exe
+        // in the root directory of the crate
+        if target.contains("msvc") {
+            cmd.arg("/c");
+        }
+
         cmd.arg(&src);
 
         let output = cmd.output()?;


### PR DESCRIPTION
Using `flag_if_supported` with `msvc` was causing an actual executable to be produced in the root directory of the compiling crate, causing dependency checks to fail and forcing recompilation without any changes.

This change adds the [`/c`](https://docs.microsoft.com/en-us/cpp/build/reference/c-compile-without-linking) flag to the compiler args so it only compiles to the object file as is the default in gcc and clang.

Resolves: #245 
