### PR TITLE
Add custom flags after -Wall

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1093,6 +1093,12 @@ impl Build {
             cmd.args.push(directory.into());
         }
 
+        if self.warnings {
+            for flag in cmd.family.warnings_flags().iter() {
+                cmd.args.push(flag.into());
+            }
+        }
+
         for flag in self.flags.iter() {
             cmd.args.push(flag.into());
         }
@@ -1109,12 +1115,6 @@ impl Build {
                 cmd.args.push(format!("{}D{}={}", lead, key, value).into());
             } else {
                 cmd.args.push(format!("{}D{}", lead, key).into());
-            }
-        }
-
-        if self.warnings {
-            for flag in cmd.family.warnings_flags().iter() {
-                cmd.args.push(flag.into());
             }
         }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -109,4 +109,14 @@ impl Execution {
     pub fn has(&self, p: &OsStr) -> bool {
         self.args.iter().any(|arg| OsStr::new(arg) == p)
     }
+
+    pub fn must_have_in_order(&self, before: &str, after: &str) -> &Execution {
+        let before_position = self.args.iter().rposition(|x| OsStr::new(x) == OsStr::new(before));
+        let after_position = self.args.iter().rposition(|x| OsStr::new(x) == OsStr::new(after));
+        match (before_position, after_position) {
+            (Some(b), Some(a)) if b < a => {},
+            (b, a) => { panic!("{:?} (last position: {:?}) did not appear before {:?} (last position: {:?})", before, b, after, a) },
+        };
+        self
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -77,11 +77,24 @@ fn gnu_warnings() {
     let test = Test::gnu();
     test.gcc()
         .warnings(true)
+        .flag("-Wno-missing-field-initializers")
         .file("foo.c")
         .compile("foo");
 
     test.cmd(0).must_have("-Wall")
                .must_have("-Wextra");
+}
+
+#[test]
+fn gnu_warnings_overridable() {
+    let test = Test::gnu();
+    test.gcc()
+        .warnings(true)
+        .flag("-Wno-missing-field-initializers")
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0).must_have_in_order("-Wall", "-Wno-missing-field-initializers");
 }
 
 #[test]


### PR DESCRIPTION
Right now we add them before, and we add -Wall by default. This allows
users to manually turn off specific warnings, without having to resort
to a dance of:

```
 .warnings(false)
 .flag("-Wall")
 .flag("-Wno-foo")
```

This strikes a good balance of keeping -Wall on by default, while
minimising the surprising experience observed in
https://github.com/alexcrichton/cc-rs/issues/235.