### PR TITLE
Add x86_64-unknown-linux-gnux32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cc"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cc-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -982,6 +982,8 @@ impl Build {
             ToolFamily::Gnu => {
                 if target.contains("i686") || target.contains("i586") {
                     cmd.args.push("-m32".into());
+                } else if target == "x86_64-unknown-linux-gnux32" {
+                    cmd.args.push("-mx32".into());
                 } else if target.contains("x86_64") || target.contains("powerpc64") {
                     cmd.args.push("-m64".into());
                 }


### PR DESCRIPTION
This is the first step in adding x86_64-unknown-linux-gnux32 target to rust. I was was able to build the  libstd using this patch.