### PR TITLE
RFC: expose tool family

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1674,6 +1674,21 @@ impl Tool {
     pub fn env(&self) -> &[(OsString, OsString)] {
         &self.env
     }
+
+    /// Whether the tool is GNU Compiler Collection-like.
+    pub fn is_like_gnu(&self) -> bool {
+        self.family == ToolFamily::Gnu
+    }
+
+    /// Whether the tool is Clang-like.
+    pub fn is_like_clang(&self) -> bool {
+        self.family == ToolFamily::Clang
+    }
+
+    /// Whether the tool is MSVC-like.
+    pub fn is_like_msvc(&self) -> bool {
+        self.family == ToolFamily::Msvc
+    }
 }
 
 fn run(cmd: &mut Command, program: &str) -> Result<(), Error> {


### PR DESCRIPTION
As described in #254, [`try_get_compiler`](https://github.com/alexcrichton/cc-rs/blob/master/src/lib.rs#L904) doesn't seem to be very useful when called externally, because `Tool`'s fields are all private. This PR exposes the field `family` and enum `ToolFamily` so it can be used in a build script (i.e. in conjunction with `cpp_set_stdlib` or other tool specific flags).

I only expose `family` in this PR because that is immediately useful to me for my build script. If any other fields from `Tool`/`Error`/any other structs should be marked `pub`, let me know and I can update this PR.

Let me know what you think (or whether this should be handled another way entirely 😃)