### PR TITLE
Separated CC/CFLAGS and command args, especially for "ccache" case.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1659,8 +1659,15 @@ impl Tool {
     /// command returned will already have the initial arguments and environment
     /// variables configured.
     pub fn to_command(&self) -> Command {
-        let mut cmd = Command::new(&self.path);
-        cmd.args(&self.cc_args);
+        let mut cmd = match self.cc_path {
+            Some(ref cc_path) => {
+                let mut cmd = Command::new(&cc_path);
+                cmd.arg(&self.path);
+                cmd.args(&self.cc_args);
+                cmd
+            },
+            None => Command::new(&self.path)
+        };
         cmd.args(&self.args);
         for &(ref k, ref v) in self.env.iter() {
             cmd.env(k, v);

--- a/tests/cc_env.rs
+++ b/tests/cc_env.rs
@@ -16,37 +16,37 @@ fn main() {
 
 fn ccache() {
     let test = Test::gnu();
-    test.shim("ccache");
 
-    env::set_var("CC", "ccache lol-this-is-not-a-compiler foo");
-    test.gcc().file("foo.c").compile("libfoo.a");
+    env::set_var("CC", "ccache cc");
+    test.gcc().file("foo.c").compile("foo");
 
     test.cmd(0)
-        .must_have("lol-this-is-not-a-compiler foo")
         .must_have("foo.c")
         .must_not_have("ccache");
+    test.cmd(1).must_have(test.td.path().join("foo.o"));
 }
 
 fn ccache_spaces() {
     let test = Test::gnu();
     test.shim("ccache");
 
-    env::set_var("CC", "ccache        lol-this-is-not-a-compiler foo");
+    env::set_var("CC", "ccache        cc");
     test.gcc().file("foo.c").compile("libfoo.a");
-    test.cmd(0).must_have("lol-this-is-not-a-compiler foo");
+    test.cmd(0).must_have("foo.c");
+    test.cmd(1).must_have(test.td.path().join("foo.o"));
 }
 
 fn distcc() {
     let test = Test::gnu();
     test.shim("distcc");
 
-    env::set_var("CC", "distcc lol-this-is-not-a-compiler foo");
-    test.gcc().file("foo.c").compile("libfoo.a");
+    env::set_var("CC", "distcc cc");
+    test.gcc().file("foo.c").compile("foo");
 
     test.cmd(0)
-        .must_have("lol-this-is-not-a-compiler foo")
         .must_have("foo.c")
         .must_not_have("distcc");
+    test.cmd(1).must_have(test.td.path().join("foo.o"));
 }
 
 fn ccache_env_flags() {
@@ -58,7 +58,7 @@ fn ccache_env_flags() {
 
     env::set_var("CC", "ccache lol-this-is-not-a-compiler");
     let compiler = test.gcc().file("foo.c").get_compiler();
-    assert_eq!(compiler.path(), Path::new("ccache"));
+    assert_eq!(compiler.path(), Path::new("lol-this-is-not-a-compiler"));
     assert_eq!(compiler.cc_env(), OsString::from("ccache lol-this-is-not-a-compiler"));
     assert!(compiler.cflags_env().into_string().unwrap().contains("ccache") == false);
     assert!(compiler.cflags_env().into_string().unwrap().contains(" lol-this-is-not-a-compiler") == false);

--- a/tests/cc_env.rs
+++ b/tests/cc_env.rs
@@ -11,6 +11,7 @@ fn main() {
     ccache();
     distcc();
     ccache_spaces();
+    ccache_env_flags();
 }
 
 fn ccache() {
@@ -46,4 +47,21 @@ fn distcc() {
         .must_have("lol-this-is-not-a-compiler foo")
         .must_have("foo.c")
         .must_not_have("distcc");
+}
+
+fn ccache_env_flags() {
+    use std::path::Path;
+    use std::ffi::OsString;
+
+    let test = Test::gnu();
+    test.shim("ccache");
+
+    env::set_var("CC", "ccache lol-this-is-not-a-compiler");
+    let compiler = test.gcc().file("foo.c").get_compiler();
+    assert_eq!(compiler.path(), Path::new("ccache"));
+    assert_eq!(compiler.cc_env(), OsString::from("ccache lol-this-is-not-a-compiler"));
+    assert!(compiler.cflags_env().into_string().unwrap().contains("ccache") == false);
+    assert!(compiler.cflags_env().into_string().unwrap().contains(" lol-this-is-not-a-compiler") == false);
+
+    env::set_var("CC", "");
 }


### PR DESCRIPTION
All apis and previous results of ```.path()``` and ```.args()``` appears unchanged, the only thing added - ```cc_env()``` and ```cflags_env``` Tool functions. This will work for backtrace-rs case. 

I am unsatisfied with introducing new vec of arguments, but run out of ideas how to avoid it :( 
 
What do you think about that methods? maybe that thing should be done in an entirely different way?  