### PR TITLE
Fix build parallelization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,7 +823,8 @@ impl Build {
 
         objs.par_iter().with_max_len(1).for_each(
             |&(ref src, ref dst)| {
-                results.lock().unwrap().push(self.compile_object(src, dst))
+                let res = self.compile_object(src, dst);
+                results.lock().unwrap().push(res)
             },
         );
 


### PR DESCRIPTION
The compile_object step was occurring within the scope of the mutex lock, so rayon wasn't actually able to execute in parallel.  This change just moves the compile out of the scope of the lock then pushes the result. 

Tested on librocksdb-sys which is a beast. Works quite well now. 