### PR TITLE
Add sparc64-unknown-linux-gnu cross-compile target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1432,6 +1432,7 @@ impl Build {
                         "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
                         "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
                         "s390x-unknown-linux-gnu" => Some("s390x-linux-gnu"),
+                        "sparc64-unknown-linux-gnu" => Some("sparc64-linux-gnu"),
                         "sparc64-unknown-netbsd" => Some("sparc64--netbsd"),
                         "sparcv9-sun-solaris" => Some("sparcv9-sun-solaris"),
                         "thumbv6m-none-eabi" => Some("arm-none-eabi"),


### PR DESCRIPTION
Hi Alex!

This small change adds the cross-compile target sparc64-linux-gnu. This is necessary to resolve issue https://github.com/rust-lang/rust/issues/45456 in Rust.

Thanks!