### PR TITLE
Don't treat 'x86_64-unknown-cloudabi-cc' as being MSVC.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1724,7 +1724,8 @@ impl Tool {
         let family = if let Some(fname) = path.file_name().and_then(|p| p.to_str()) {
             if fname.contains("clang") {
                 ToolFamily::Clang
-            } else if fname.contains("cl") && !fname.contains("uclibc") {
+            } else if fname.contains("cl") && !fname.contains("cloudabi") &&
+                      !fname.contains("uclibc") {
                 ToolFamily::Msvc
             } else {
                 ToolFamily::Gnu


### PR DESCRIPTION
Though the name contains 'cl', it should not be treated as Microsoft's
cl.exe.