### PR TITLE
Cache is_flag_supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,12 +400,17 @@ impl Build {
     ///
     /// It may return error if it's unable to run the compilier with a test file
     /// (e.g. the compiler is missing or a write to the `out_dir` failed).
+    ///
+    /// Note: Once computed, the result of this call is stored in the
+    /// `known_flag_support` field. If `is_flag_supported(flag)`
+    /// is called again, the result will be read from the hash table.
     pub fn is_flag_supported(&self, flag: &str) -> Result<bool, Error> {
         let known_status = self.known_flag_support_status.lock().ok()
             .and_then(|flag_status| flag_status.get(flag).cloned());
         if let Some(is_supported) = known_status {
             return Ok(is_supported)
         }
+
         let out_dir = self.get_out_dir()?;
         let src = self.ensure_check_file()?;
         let obj = out_dir.join("flag_check");


### PR DESCRIPTION
Hey,

recently I've investigated been annoyed by slow build times of [tectonic-typesetting/tectonic](https://github.com/tectonic-typesetting/tectonic).
The project compiles 95 [object files](https://github.com/tectonic-typesetting/tectonic/blob/master/build.rs#L201) with and sets about 25 build flags using `flag_if_supported`.
Even with <50ms per internal call to `is_flag_supported` this outweighs the actual time spent compiling the object files.

In the case of `tectonic` this change reduces the build_script phase from 90s to 18s.
I'm not particularly satisfied with my implementation though as it's pretty hacky ~and pollutes the _astonishingly_ clean set of dependencies~.
_Alternatively one could fix the problem in the build script by using the recently exposed `is_flag_supported`._

If you'd prefer a different solution to this problem, let me know!
  
  