### PR TITLE
Microsoft ARM/ARM64 compiler support

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -497,6 +497,7 @@ mod impl_ {
             "i586" | "i686" => Some("x86"),
             "x86_64" => Some("x64"),
             "arm" => Some("arm"),
+            "aarch64" => Some("arm64"),
             _ => None,
         }
     }
@@ -508,6 +509,7 @@ mod impl_ {
             "i586" | "i686" => Some(""),
             "x86_64" => Some("amd64"),
             "arm" => Some("arm"),
+            "aarch64" => Some("arm64"),
             _ => None,
         }
     }


### PR DESCRIPTION
VS2017 supports upcoming ARM64 desktop Windows support.  But cc-rs does't support it yet, so I would like to support it.

armasm and armasm64 don't support -c options and thes uses -o for output file option.