### PR TITLE
Add powerpc-unknown-linux-gnuspe cross-compile target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1526,6 +1526,7 @@ impl Build {
                         "mips64-unknown-linux-gnuabi64" => Some("mips64-linux-gnuabi64"),
                         "mips64el-unknown-linux-gnuabi64" => Some("mips64el-linux-gnuabi64"),
                         "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
+                        "powerpc-unknown-linux-gnuspe" => Some("powerpc-linux-gnuspe"),
                         "powerpc-unknown-netbsd" => Some("powerpc--netbsd"),
                         "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
                         "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),


### PR DESCRIPTION
This adds the powerpc-unknown-linux-gnuspe cross-compile target necessary to cross-compile Rust code for Linux/powerpcspe.