### PR TITLE
Add sparc-unknown-linux-gnu cross-compile target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1531,6 +1531,7 @@ impl Build {
                         "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
                         "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),
                         "s390x-unknown-linux-gnu" => Some("s390x-linux-gnu"),
+                        "sparc-unknown-linux-gnu" => Some("sparc-linux-gnu"),
                         "sparc64-unknown-linux-gnu" => Some("sparc64-linux-gnu"),
                         "sparc64-unknown-netbsd" => Some("sparc64--netbsd"),
                         "sparcv9-sun-solaris" => Some("sparcv9-sun-solaris"),


### PR DESCRIPTION
This adds the sparc-unknown-linux-gnu cross-compile target necessary to cross-compile Rust code for Linux/sparc.