### PR TITLE
Msvc needs /O1 (which implies /Os) to generate smallest binaries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1054,8 +1054,8 @@ impl Build {
                 cmd.args.push(crt_flag.into());
 
                 match &opt_level[..] {
-                    "z" | "s" => cmd.args.push("/Os".into()),
-                    "1" => cmd.args.push("/O1".into()),
+                    // Msvc uses /O1 to enable all optimizations that minimize code size.
+                    "z" | "s" | "1" => cmd.args.push("/O1".into()),
                     // -O3 is a valid value for gcc and clang compilers, but not msvc. Cap to /O2.
                     "2" | "3" => cmd.args.push("/O2".into()),
                     _ => {}


### PR DESCRIPTION
As said on msdn:
https://docs.microsoft.com/en-us/cpp/build/reference/o1-o2-minimize-size-maximize-speed

`/Os` alone doesn't seem to enable any actual optimizations, and `/O1` also sets `/Os`

I compared code size of some functions in miniz-sys crate with different optimization flags to see how much it actually makes a difference
```
With /O2
tinfl_decompress        5666 bytes
tdefl_flush_block       1880 bytes
tdefl_compress_fast     1444 bytes

With /Os
tinfl_decompress        12244 bytes
tdefl_flush_block       3564 bytes
tdefl_compress_fast     2242 bytes

With /O1
tinfl_decompress        5168 bytes
tdefl_flush_block       1270 bytes
tdefl_compress_fast     1346 bytes
```
