### PR TITLE
Pass -static depending on crt-static on linux too.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1106,8 +1106,11 @@ impl Build {
                     cmd.args.push("-m64".into());
                 }
 
-                if self.static_flag.is_none() && target.contains("musl") {
-                    cmd.args.push("-static".into());
+                if self.static_flag.is_none() {
+                    let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or(String::new());
+                    if features.contains("crt-static") {
+                        cmd.args.push("-static".into());
+                    }
                 }
 
                 // armv7 targets get to use armv7 instructions


### PR DESCRIPTION
This is the done the same way as it's already done for msvc.

This is one piece still missing to compile rustc on a musl host with internal llvm (the llvm build process builds at least one shared library, LLVMHello.so, that fails to link with -static in CFLAGS).