### PR TITLE
Don't override host when checking supported flags.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,10 +413,12 @@ impl Build {
         let src = self.ensure_check_file()?;
         let obj = out_dir.join("flag_check");
         let target = self.get_target()?;
+        let host = self.get_host()?;
         let mut cfg = Build::new();
         cfg.flag(flag)
             .target(&target)
             .opt_level(0)
+            .host(&host)
             .debug(false)
             .cpp(self.cpp)
             .cuda(self.cuda);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,6 @@ impl Build {
         cfg.flag(flag)
             .target(&target)
             .opt_level(0)
-            .host(&target)
             .debug(false)
             .cpp(self.cpp)
             .cuda(self.cuda);


### PR DESCRIPTION
This has an impact on cross-compilation, since it affects whether HOST_CFLAGS/HOST_CXXFLAGS/HOST_CC/HOST_CXX will be selected and can impact whether a compilation succeeds or not.