### PR TITLE
Find devenv and MSBuild via SetupConfiguration rather than registry keys

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -251,6 +251,7 @@ mod impl_ {
                     .and_then(|instance| instance.installation_path().ok())
             })
             .map(|ip| PathBuf::from(ip).join(tool))
+            .filter(|ref path| path.is_file())
             .map(|path| {
                 let mut tool = Tool::new(path);
                 if target.contains("x86_64") {

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -174,7 +174,7 @@ mod impl_ {
     use std::io::Read;
     use registry::{RegistryKey, LOCAL_MACHINE};
     use com;
-    use setup_config::{SetupConfiguration, SetupInstance};
+    use setup_config::{EnumSetupInstances, SetupConfiguration, SetupInstance};
 
     use Tool;
 
@@ -217,11 +217,15 @@ mod impl_ {
     // Note that much of this logic can be found [online] wrt paths, COM, etc.
     //
     // [online]: https://blogs.msdn.microsoft.com/vcblog/2017/03/06/finding-the-visual-c-compiler-tools-in-visual-studio-2017/
-    pub fn find_msvc_15(tool: &str, target: &str) -> Option<Tool> {
+    fn vs15_instances() -> Option<EnumSetupInstances> {
         otry!(com::initialize().ok());
 
         let config = otry!(SetupConfiguration::new().ok());
-        let iter = otry!(config.enum_all_instances().ok());
+        config.enum_all_instances().ok()
+    }
+
+    pub fn find_msvc_15(tool: &str, target: &str) -> Option<Tool> {
+        let iter = otry!(vs15_instances());
         for instance in iter {
             let instance = otry!(instance.ok());
             let tool = tool_from_vs15_instance(tool, target, &instance);


### PR DESCRIPTION
The comment in `find_msbuild_vs15()` says:
https://github.com/alexcrichton/cc-rs/blob/c44f4df6a136f682dfb4d9f42718c38021edeb45/src/windows_registry.rs#L660-L663

After I recently uninstalled a bunch of older MSVC versions using [Visual Studio Uninstaller](https://github.com/Microsoft/VisualStudioUninstaller), that registry key also was deleted in the process, even though Visual Studio 2017 *itself* wasn't, and still worked fine.

Steps to reproduce:
1. Install Visual Studio 2017 Community with the *Desktop development with C++* workload on a fresh Windows system. (I tested with version 15.7.6.)
2. Confirm that `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7\15.0` points to the installation directory.
3. Run the [Visual Studio Uninstaller](https://github.com/Microsoft/VisualStudioUninstaller) on that same system.
4. The registry key is now gone, but Visual Studio 2017 IDE still works and can compile code.
6. The following Rust code then runs without panicking:
```rust
extern crate cc;

use cc::windows_registry::find_tool;

fn main() {
	// Change this if your test system is 32-bit
	let target = "x86_64-pc-windows-msvc";
	assert_eq!(find_tool(target, "devenv.exe").is_none(), true);
	assert_eq!(find_tool(target, "link.exe").is_some(), true);
	// msbuild.exe will fall back on find_old_msbuild(), which will
	// find a version under a different registry key.
}
```

Which means that `link.exe` can still be found just fine through SetupConfiguration. This may be a bug in Visual Studio Uninstaller, but it also matches [what Microsoft says about the reliability of these registry keys, and that SetupConfiguration should be preferred](https://developercommunity.visualstudio.com/comments/215399/view.html).