### PR TITLE
Filter out -v from compiler args when checking if a flag is supported.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.13.0
+    - rust: 1.16.0
       install:
       script: cargo build
     - rust: stable

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -230,12 +230,14 @@ fn gnu_flag_if_supported() {
     let test = Test::gnu();
     test.gcc()
         .file("foo.c")
+        .flag("-v")
         .flag_if_supported("-Wall")
         .flag_if_supported("-Wflag-does-not-exist")
         .flag_if_supported("-std=c++11")
         .compile("foo");
 
     test.cmd(0)
+        .must_have("-v")
         .must_have("-Wall")
         .must_not_have("-Wflag-does-not-exist")
         .must_not_have("-std=c++11");


### PR DESCRIPTION
Fixes #329. I didn't write an automated test because I didn't see a way to inject the args outside of environment variables, and doing that in unit tests that run concurrently seems dangerous.