### PR TITLE
Compiling with Rust 1.14.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2019,8 +2019,8 @@ impl Tool {
         };
         cmd.args(&self.cc_wrapper_args);
 
-        let value = self.args.iter().filter(|a| !self.removed_args.contains(a)).map(|a| a).collect::<Vec<_>>();
-        cmd.args(&value[..]);
+        let value = self.args.iter().filter(|a| !self.removed_args.contains(a)).collect::<Vec<_>>();
+        cmd.args(&value);
 
         for &(ref k, ref v) in self.env.iter() {
             cmd.env(k, v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,7 +2018,10 @@ impl Tool {
             None => Command::new(&self.path),
         };
         cmd.args(&self.cc_wrapper_args);
-        cmd.args(self.args.iter().filter(|a| !self.removed_args.contains(a)));
+
+        let value = self.args.iter().filter(|a| !self.removed_args.contains(a)).map(|a| a).collect::<Vec<_>>();
+        cmd.args(&value[..]);
+
         for &(ref k, ref v) in self.env.iter() {
             cmd.env(k, v);
         }


### PR DESCRIPTION
Regarding issue #336... 

The following changes allow for cc-rs to be built on Rust 1.14.0, however it fails to pass "cargo test" on Rust 1.14.0. These changes build and test successfully on the most recent version or Rust.

It seems like the macro #![cfg_attr(test, deny(warnings))] overshadows #[allow(non_camel_case_types)] under "__Nonexhaustive_do_not_match_this_or_your_code_will_break".

I'm not quite sure what is the best way to approach this issue, as it seems like any changes could break things for the more recent versions of Rust. 