### PR TITLE
don't enable warnings by default if CFLAGS/CXXFLAGS defined in environment

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,7 @@
 extern crate cc;
 extern crate tempdir;
 
+use std::env;
 use support::Test;
 
 mod support;
@@ -108,6 +109,30 @@ fn gnu_warnings_overridable() {
 
     test.cmd(0)
         .must_have_in_order("-Wall", "-Wno-missing-field-initializers");
+}
+
+#[test]
+fn gnu_no_warnings_if_cflags() {
+    env::set_var("CFLAGS", "-Wflag-does-not-exist");
+    let test = Test::gnu();
+    test.gcc()
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
+    env::set_var("CFLAGS", "");
+}
+
+#[test]
+fn gnu_no_warnings_if_cxxflags() {
+    env::set_var("CXXFLAGS", "-Wflag-does-not-exist");
+    let test = Test::gnu();
+    test.gcc()
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
+    env::set_var("CXXFLAGS", "");
 }
 
 #[test]


### PR DESCRIPTION
If CFLAGS/CXXFLAGS is defined in the environment, then presumably the consumer has already determined the set of warnings flags to pass to the compiler, so we shouldn't enable warnings by default in that case.

I'd hoped to use this change to help address [bug 1482810](https://bugzilla.mozilla.org/show_bug.cgi?id=1482810), but I'm not sure it'll actually work for that, since [this Makefile snippet](https://searchfox.org/mozilla-central/rev/55da592d85c2baf8d8818010c41d9738c97013d2/config/rules.mk#908-939) shows that Mozilla's build system doesn't pass CFLAGS/CXXFLAGS to Cargo on Windows, so this change won't disable warnings by default there.

It might still be worth taking, which is why I'm opening this pull request (while I continue to look for a more robust and general solution in that bug).


