### PR TITLE
Bump to 1.0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc"
-version = "1.0.22"
+version = "1.0.23"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cc-rs"


### PR DESCRIPTION
@alexcrichton Would it be possible for you to bump the patch version and publish a new release to crates.io? That'd enable me to vendor the latest changes into mozilla-central to help resolve [bug 1482810](https://bugzilla.mozilla.org/show_bug.cgi?id=1482810).
