### PR TITLE
msvc: find tools correctly when target is thumbv7a

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -523,8 +523,8 @@ mod impl_ {
             ("i586", X86_64) | ("i686", X86_64) => vec![("amd64_x86", "amd64"), ("", "")],
             ("x86_64", X86) => vec![("x86_amd64", "")],
             ("x86_64", X86_64) => vec![("amd64", "amd64"), ("x86_amd64", "")],
-            ("arm", X86) => vec![("x86_arm", "")],
-            ("arm", X86_64) => vec![("amd64_arm", "amd64"), ("x86_arm", "")],
+            ("arm", X86) | ("thumbv7a", X86) => vec![("x86_arm", "")],
+            ("arm", X86_64) | ("thumbv7a", X86_64) => vec![("amd64_arm", "amd64"), ("x86_arm", "")],
             _ => vec![],
         }
     }
@@ -534,7 +534,7 @@ mod impl_ {
         match arch {
             "i586" | "i686" => Some("x86"),
             "x86_64" => Some("x64"),
-            "arm" => Some("arm"),
+            "arm" | "thumbv7a" => Some("arm"),
             "aarch64" => Some("arm64"),
             _ => None,
         }
@@ -546,7 +546,7 @@ mod impl_ {
         match arch {
             "i586" | "i686" => Some(""),
             "x86_64" => Some("amd64"),
-            "arm" => Some("arm"),
+            "arm" | "thumbv7a" => Some("arm"),
             "aarch64" => Some("arm64"),
             _ => None,
         }


### PR DESCRIPTION
This change enables cc-rs to find the MSVC tools when the target architecture is thumbv7a, which is the target architecture for windows/ARM.