### PR TITLE
Search for longer target component first when replacing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1649,10 +1649,10 @@ impl Build {
                     }
                 } else if target.contains("android") {
                     let target = target
-                        .replace("armv7", "arm")
                         .replace("armv7neon", "arm")
-                        .replace("thumbv7", "arm")
-                        .replace("thumbv7neon", "arm");
+                        .replace("armv7", "arm")
+                        .replace("thumbv7neon", "arm")
+                        .replace("thumbv7", "arm");
                     let gnu_compiler = format!("{}-{}", target, gnu);
                     let clang_compiler = format!("{}-{}", target, clang);
                     // Check if gnu compiler is present


### PR DESCRIPTION
Search for `thumbv7neon` before `thumbv7` and `armv7neon` before `armv7` when replacing to avoid unwanted substring matches. I expect this to solve the build problem with [`thumbv7neon-linux-androideabi`](https://github.com/rust-lang/rust/pull/49902).