### PR TITLE
Generate valid intructions on ARMv6 (see rust-lang/rust issue #50583)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1249,6 +1249,7 @@ impl Build {
                 if target.starts_with("arm-unknown-linux-") {
                     cmd.args.push("-march=armv6".into());
                     cmd.args.push("-marm".into());
+                    cmd.args.push("-mfpu=vfp".into());
                 }
 
                 // We can guarantee some settings for FRC

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1249,7 +1249,11 @@ impl Build {
                 if target.starts_with("arm-unknown-linux-") {
                     cmd.args.push("-march=armv6".into());
                     cmd.args.push("-marm".into());
-                    cmd.args.push("-mfpu=vfp".into());
+                    if target.ends_with("hf") {
+                        cmd.args.push("-mfpu=vfp".into());
+                    } else {
+                        cmd.args.push("-mfloat-abi=soft".into());
+                    }
                 }
 
                 // We can guarantee some settings for FRC


### PR DESCRIPTION
I have tested this by generating a test C program containing an ARMv6 illegal instruction as follows:

```
void main()
{
  asm("vmov.f64        d10, #1.0");
}
```

Then compiling it via the cc crate - without this fix the program compiles find (and shouldn't).  After the fix the compilation fails (as it should).  Obviously this is a slightly contrived scenario, but couldn't immediately invent some C which would end up generating the illegal instruction.