### PR TITLE
Fix build on previous versions of rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.30.0
+    - rust: 1.16.0
       install:
       script: cargo build
     - rust: stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 
 #![doc(html_root_url = "https://docs.rs/cc/1.0")]
 #![cfg_attr(test, deny(warnings))]
+#![allow(deprecated)]
 #![deny(missing_docs)]
 
 #[cfg(feature = "parallel")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1719,7 +1719,7 @@ impl Build {
                 } else if self.get_host()? != target {
                     // CROSS_COMPILE is of the form: "arm-linux-gnueabi-"
                     let cc_env = self.getenv("CROSS_COMPILE");
-                    let cross_compile = cc_env.as_ref().map(|s| s.trim_end_matches('-'));
+                    let cross_compile = cc_env.as_ref().map(|s| s.trim_right_matches('-'));
                     let prefix = cross_compile.or(match &target[..] {
                         "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
                         "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),


### PR DESCRIPTION
Switching to a function due to deprecation when it isn't even deprecated yet, let alone removed, seems significantly premature, and breaks lots of downstream users.

Addresses the non-meta part of #364.