### PR TITLE
Don't add default flags that conflict with _FLAGS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2178,18 +2178,19 @@ impl Tool {
         // Get flag name and set a flag for value-bearing flags
         let value_chars: &[_] = &['=', ':'];
         let (name_part, has_value) = if let Some(idx) = flag.find(value_chars) {
-            (&flag[1..idx], true)
+            (&flag[0..idx], true)
         } else {
-            (&flag[1..], false)
+            (flag, false)
         };
 
         // Mutually exclusive flags - a maximum of one value from each of these
         // groups may be used
-        // Note: all flags should have the first charachter removed (`-`, `/`)
         let mutually_exclusive_groups = &[
-            vec!["m32", "m64", "mx32"],
-            vec!["mbig-endian", "mlittle-endian"],
-            vec!["O0", "O1", "O2", "O3", "Os", "Oz"],
+            vec!["-m32", "-m64", "-mx32"],
+            vec!["-mbig-endian", "-mlittle-endian"],
+            vec![
+                "-O0", "-O1", "-O2", "-O3", "-Os", "-Oz", "/O0", "/O1", "/O2", "/O3", "/Os", "/Oz",
+            ],
         ];
 
         for group in mutually_exclusive_groups {
@@ -2197,7 +2198,7 @@ impl Tool {
                 return self.args().iter().any(|ref arg| {
                     if let Some(arg) = arg.to_str() {
                         // See if any existing arg is in this group
-                        group.contains(&&arg[1..])
+                        group.contains(&arg)
                     } else {
                         false
                     }
@@ -2205,27 +2206,28 @@ impl Tool {
             }
         }
 
-        // Note: all flags should have the first charachter removed (`-`, `/`)
         let exclusive_value_flags = &[
-            "-target",
-            "arch",
-            "ARCH",
-            "march",
-            "mcpu",
-            "mfloat-abi",
-            "mfpu",
-            "mios-simulator-version-min",
-            "miphoneos-version-min",
-            "stdlib",
+            "--target",
+            "-arch",
+            "-ARCH",
+            "/arch",
+            "/ARCH",
+            "-march",
+            "-mcpu",
+            "-mfloat-abi",
+            "-mfpu",
+            "-mios-simulator-version-min",
+            "-miphoneos-version-min",
+            "-stdlib",
         ];
         if has_value {
             // Exclusive value flags - each of these flags carries a value and each
             // should only be used a maximum of one time
-            // march=, -target=, arch:
+            // -march=, --target=, /arch:
             if exclusive_value_flags.contains(&name_part) {
                 return self.args().iter().any(|ref arg| {
                     if let Some(arg) = arg.to_str() {
-                        arg[1..].starts_with(name_part)
+                        arg.starts_with(name_part)
                     } else {
                         false
                     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -132,6 +132,37 @@ fn gnu_no_warnings_if_cxxflags() {
 }
 
 #[test]
+fn gnu_no_duplicate_march_after_cflags() {
+    env::set_var("CFLAGS", "-march=armv7ve");
+    let test = Test::gnu();
+
+    test.gcc()
+        .target("armv7-unknown-linux-gnu")
+        .file("foo.c")
+        .compile("foo");
+
+    test.cmd(0)
+        .must_have("-march=armv7ve")
+        .must_not_have("-march=armv7-a");
+    env::set_var("CFLAGS", "");
+}
+
+#[test]
+fn gnu_prefer_cflags_over_defaults() {
+    env::set_var("CFLAGS", "-m32");
+    let test = Test::gnu();
+    test.gcc()
+        .target("x86_64-unknown-linux-gnu")
+        .file("foo.c")
+        .compile("foo");
+
+    // This is contrived and probably not valid for real builds, but it
+    // validates that we use the incoming CFLAGS over the default flags.
+    test.cmd(0).must_have("-m32").must_not_have("-m64");
+    env::set_var("CFLAGS", "");
+}
+
+#[test]
 fn gnu_x86_64() {
     for vendor in &["unknown-linux-gnu", "apple-darwin"] {
         let target = format!("x86_64-{}", vendor);


### PR DESCRIPTION
This is an evolution of https://github.com/alexcrichton/cc-rs/pull/374. That PR was too naive with duplicate flag checking and ended up causing problems.

This change organizes flags into two groups: flags that do not carry a value and are mutually exclusive (`-m64, -m32`) and flags that carry a value that should only be set once (`-march=, -mcpu=`). Both groups are handled separately.