### PR TITLE
Add support for uwp targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,7 +1219,8 @@ impl Build {
                     cmd.push_cc_arg("-ffunction-sections".into());
                     cmd.push_cc_arg("-fdata-sections".into());
                 }
-                if self.pic.unwrap_or(!target.contains("windows-gnu")) {
+                if self.pic.unwrap_or(!target.contains("windows-gnu") &&
+                                      !target.contains("uwp-gnu")) {
                     cmd.push_cc_arg("-fPIC".into());
                     // PLT only applies if code is compiled with PIC support,
                     // and only for ELF targets.
@@ -1781,6 +1782,8 @@ impl Build {
                         "armv7-unknown-netbsd-eabihf" => Some("armv7--netbsdelf-eabihf"),
                         "i586-unknown-linux-musl" => Some("musl"),
                         "i686-pc-windows-gnu" => Some("i686-w64-mingw32"),
+                        "i686-pc-uwp-gnu" => Some("i686-w64-mingw32"),
+                        "x86_64-pc-uwp-gnu" => Some("x86_64-w64-mingw32"),
                         "i686-unknown-linux-musl" => Some("musl"),
                         "i686-unknown-netbsd" => Some("i486--netbsdelf"),
                         "mips-unknown-linux-gnu" => Some("mips-linux-gnu"),


### PR DESCRIPTION
Hi,

This MR is related to rust-lang/rust#60260, and allows the use of "uwp" as part of the target.

I'm unsure what the best way is, when it comes to cross dependent MRs, so I'll gladly change things according to your reviews!

As noted in the rust-lang MR, the i686 target isn't fully functional, due to a mismatch in the stack unwinding model (LLVM's libunwind assumes SjLj when targeting i686, rust-lang assumes SEH will be available)

Thanks,