### PR TITLE
Automatically check if README.md examples are working when running "cargo test"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ parallel = ["rayon"]
 
 [dev-dependencies]
 tempdir = "0.3"
+doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,13 @@
 #[cfg(feature = "parallel")]
 extern crate rayon;
 
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
+
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.