### PR TITLE
Recognize the "wasm32-wasi" target tuple.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1751,7 +1751,9 @@ impl Build {
                     }
                 } else if target.contains("cloudabi") {
                     format!("{}-{}", target, traditional)
-                } else if target == "wasm32-unknown-wasi" || target == "wasm32-unknown-unknown" {
+                } else if target == "wasm32-wasi" ||
+                          target == "wasm32-unknown-wasi" ||
+                          target == "wasm32-unknown-unknown" {
                     "clang".to_string()
                 } else if self.get_host()? != target {
                     // CROSS_COMPILE is of the form: "arm-linux-gnueabi-"


### PR DESCRIPTION
To minimize confusion with [multiarch tuples](https://wiki.debian.org/Multiarch/Tuples) which omit the vendor field of the target tuple, and to save a small amount of typing, we're preparing to switch the "wasm32-unknown-wasi" target to be spelled "wasm32-wasi". LLVM already accepts both forms. This is similar to how the vendor field is omitted in rustc tuples such as "x86_64-fuchsia" and "aarch64-linux-android".

The patch here just changes the cc-rs crate to recognize either form in anticipation of this change.