### PR TITLE
Remove ppa:ubuntu-toolchain-r/test from Azure Pipelines

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -3,6 +3,13 @@ steps:
   - bash: rustup target add $TARGET
     displayName: Install Rust target
 
+  # Remove the ubuntu-toolchain-r/test PPA, which is added by default. Some
+  # packages were removed, and this is causing the g++multilib install to fail.
+  # Similar issue: https://github.com/scikit-learn/scikit-learn/issues/13928
+  - bash: sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test
+    condition: eq( variables['Agent.OS'], 'Linux' )
+    displayName: Remove ppa:ubuntu-toolchain-r/test
+
   - bash: sudo apt-get install g++-multilib
     condition: eq( variables['Agent.OS'], 'Linux' )
     displayName: Install g++-multilib


### PR DESCRIPTION
Remove the `ubuntu-toolchain-r/test` PPA, which is added by default. Some packages were removed, and this is causing the `g++multilib` install to fail.

See https://github.com/scikit-learn/scikit-learn/issues/13928 for a similar experience.