### PR TITLE
Remove master branch trigger on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,3 @@
-trigger:
-  - master
-
 jobs:
   - job: min_linux
     pool:


### PR DESCRIPTION
This PR removes a [`trigger` configuration](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers) that prevents me from testing non-`master` branches on a fork. I'm curious about the motivation behind it. If there's a good reason for it, feel free to close this PR without merging; it's easy enough to work around.