### PR TITLE
Set default compiler to clang on apple hosts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1426,8 +1426,6 @@ impl Build {
         }
 
         if target.contains("-ios") {
-            // FIXME: potential bug. iOS is always compiled with Clang, but Gcc compiler may be
-            // detected instead.
             self.ios_flags(cmd)?;
         }
 
@@ -1682,9 +1680,12 @@ impl Build {
             ("CC", "cl.exe", "gcc", "cc", "clang")
         };
 
-        // On Solaris, c++/cc unlikely to exist or be correct.
         let default = if host.contains("solaris") {
+            // On Solaris, cc/c++ is unlikely to exist or be correct.
             gnu
+        } else if host.contains("apple") {
+            // On macOS, this allows us to correctly identify the ToolFamily.
+            clang
         } else {
             traditional
         };


### PR DESCRIPTION
The change in this PR (615c53bf23b3a026b90a613c6364dd6ade869cd1) _seems_ to be the right choice to make. `clang`/`clang++` should be considered the default on macOS, and it allows the `ToolFamily` to be chosen correctly based on the name.

Many tests fail, however, and I believe that's because (a) they are duplicated for Linux and macOS targets and (b) each uses the same target and host. For example, consider this test from `tests/test.rs`:

```rust
#[test]
fn gnu_x86_64() {
    for vendor in &["unknown-linux-gnu", "apple-darwin"] {
        let target = format!("x86_64-{}", vendor);
        let test = Test::gnu();
        test.gcc()
            .target(&target)
            .host(&target)
            .file("foo.c")
            .compile("foo");
        test.cmd(0).must_have("-fPIC").must_have("-m64");
    }   
}
```

So, first, is my premise about choosing the default compiler on macOS is correct? If so, how should the tests change?