### PR TITLE
Implement Display for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ extern crate rayon;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::fmt::{self, Display};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -159,6 +160,12 @@ impl Error {
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {
         Error::new(ErrorKind::IOError, &format!("{}", e))
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}: {}", self.kind, self.message)
     }
 }
 


### PR DESCRIPTION
I want to be able to use Build::try_compile, and display the error nicely in case of failure.
Unfortunately, `cc::Error` currently only implement Debug, and the result is not so pretty.
So by implementing the Display trait, one can have slightly better output.

Debug: 
```
Error { kind: ToolExecError, message: "Command \"c++\" \"-O0\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"-m64\" \"-I\" \"/home/rust/rust-cpp/test\" \"-Wall\" \"-Wextra\" \"-std=c++11\" \"-o\" \"/tmp/rust_target/debug/build/cpp_test-978efbf415ae7e87/out/rust_cpp/cpp_closures.o\" \"-c\" \"/tmp/rust_target/debug/build/cpp_test-978efbf415ae7e87/out/rust_cpp/cpp_closures.cpp\" with args \"c++\" did not execute successfully (status code exit code: 1)." }
```

Display (new): 
```
ToolExecError: Command "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "/home/rust/rust-cpp/test" "-Wall" "-Wextra" "-std=c++11" "-o" "/tmp/rust_target/debug/build/cpp_test-6bd038a61091820c/out/rust_cpp/cpp_closures.o" "-c" "/tmp/rust_target/debug/build/cpp_test-6bd038a61091820c/out/rust_cpp/cpp_closures.cpp" with args "c++" did not execute successfully (status code exit code: 1).`
```

I'm not sure if the format is the right one. Is the `kind` at all relevant? 