### PR TITLE
Create temp dir in same dir as gcc-shim

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -26,9 +26,10 @@ impl Test {
         if gcc.ends_with("deps") {
             gcc.pop();
         }
+        let td = TempDir::new_in(&gcc, "gcc-test").unwrap();
         gcc.push(format!("gcc-shim{}", env::consts::EXE_SUFFIX));
         Test {
-            td: TempDir::new("gcc-test").unwrap(),
+            td: td,
             gcc: gcc,
             msvc: false,
         }


### PR DESCRIPTION
In case the temporary director is not deleted, this makes it easy to find. It also means that it will get removed when `cargo clean` removes the target directory.