### PR TITLE
Fix occasional test failure due to env::set_var with multiple test threads

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -16,9 +16,9 @@ steps:
 
   - script: cargo build
     displayName: "Normal build"
-  - bash: cargo test $NO_RUN -- --test-threads 1
+  - bash: cargo test $NO_RUN
     displayName: "Crate tests"
-  - bash: cargo test $NO_RUN --features parallel -- --test-threads 1
+  - bash: cargo test $NO_RUN --features parallel
     displayName: "Crate tests (parallel)"
   - bash: cargo test $NO_RUN --manifest-path cc-test/Cargo.toml --target $TARGET
     displayName: "cc-test tests"

--- a/tests/cflags.rs
+++ b/tests/cflags.rs
@@ -1,0 +1,18 @@
+extern crate cc;
+extern crate tempdir;
+
+mod support;
+
+use std::env;
+use support::Test;
+
+/// This test is in its own module because it modifies the environment and would affect other tests
+/// when run in parallel with them.
+#[test]
+fn gnu_no_warnings_if_cflags() {
+    env::set_var("CFLAGS", "-arbitrary");
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
+}

--- a/tests/cxxflags.rs
+++ b/tests/cxxflags.rs
@@ -1,0 +1,18 @@
+extern crate cc;
+extern crate tempdir;
+
+mod support;
+
+use std::env;
+use support::Test;
+
+/// This test is in its own module because it modifies the environment and would affect other tests
+/// when run in parallel with them.
+#[test]
+fn gnu_no_warnings_if_cxxflags() {
+    env::set_var("CXXFLAGS", "-arbitrary");
+    let test = Test::gnu();
+    test.gcc().file("foo.cpp").cpp(true).compile("foo");
+
+    test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,6 @@
 extern crate cc;
 extern crate tempdir;
 
-use std::env;
 use support::Test;
 
 mod support;
@@ -109,26 +108,6 @@ fn gnu_warnings_overridable() {
 
     test.cmd(0)
         .must_have_in_order("-Wall", "-Wno-missing-field-initializers");
-}
-
-#[test]
-fn gnu_no_warnings_if_cflags() {
-    env::set_var("CFLAGS", "-Wflag-does-not-exist");
-    let test = Test::gnu();
-    test.gcc().file("foo.c").compile("foo");
-
-    test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
-    env::set_var("CFLAGS", "");
-}
-
-#[test]
-fn gnu_no_warnings_if_cxxflags() {
-    env::set_var("CXXFLAGS", "-Wflag-does-not-exist");
-    let test = Test::gnu();
-    test.gcc().file("foo.c").compile("foo");
-
-    test.cmd(0).must_not_have("-Wall").must_not_have("-Wextra");
-    env::set_var("CXXFLAGS", "");
 }
 
 #[test]


### PR DESCRIPTION
Tests that modify environment variables (e.g. `CFLAGS` and `CXXFLAGS`) can cause tests to fail when run in parallel because they change a shared context.

This change moves the problematic tests into separate modules. Since each `tests/*.rs` is compiled as a separate crate, these tests are not run in parallel with other tests.