### PR TITLE
Add CUDA support for MSVC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,14 @@ impl Build {
 
         let mut cmd = compiler.to_command();
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(&mut cmd, &obj, self.cuda, target.contains("msvc"), false, is_arm);
+        command_add_output_file(
+            &mut cmd,
+            &obj,
+            self.cuda,
+            target.contains("msvc"),
+            false,
+            is_arm,
+        );
 
         // We need to explicitly tell msvc not to link and create an exe
         // in the root directory of the crate
@@ -1183,7 +1190,10 @@ impl Build {
                     cmd.push_cc_arg("-fdata-sections".into());
                 }
                 // Disable generation of PIC on RISC-V for now: rust-lld doesn't support this yet
-                if self.pic.unwrap_or(!target.contains("windows-gnu") && !target.contains("riscv")) {
+                if self
+                    .pic
+                    .unwrap_or(!target.contains("windows-gnu") && !target.contains("riscv"))
+                {
                     cmd.push_cc_arg("-fPIC".into());
                     // PLT only applies if code is compiled with PIC support,
                     // and only for ELF targets.
@@ -1234,7 +1244,8 @@ impl Build {
                 // the SDK, but for all released versions of the
                 // Windows SDK it is required.
                 if target.contains("arm") || target.contains("thumb") {
-                    cmd.args.push("-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1".into());
+                    cmd.args
+                        .push("-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1".into());
                 }
             }
             ToolFamily::Gnu => {
@@ -1588,19 +1599,21 @@ impl Build {
             }
         };
 
-        let min_version = std::env::var("IPHONEOS_DEPLOYMENT_TARGET")
-                .unwrap_or_else(|_| "7.0".into());
+        let min_version =
+            std::env::var("IPHONEOS_DEPLOYMENT_TARGET").unwrap_or_else(|_| "7.0".into());
 
         let sdk = match arch {
             ArchSpec::Device(arch) => {
                 cmd.args.push("-arch".into());
                 cmd.args.push(arch.into());
-                cmd.args.push(format!("-miphoneos-version-min={}", min_version).into());
+                cmd.args
+                    .push(format!("-miphoneos-version-min={}", min_version).into());
                 "iphoneos"
             }
             ArchSpec::Simulator(arch) => {
                 cmd.args.push(arch.into());
-                cmd.args.push(format!("-mios-simulator-version-min={}", min_version).into());
+                cmd.args
+                    .push(format!("-mios-simulator-version-min={}", min_version).into());
                 "iphonesimulator"
             }
         };
@@ -1732,9 +1745,10 @@ impl Build {
                     }
                 } else if target.contains("cloudabi") {
                     format!("{}-{}", target, traditional)
-                } else if target == "wasm32-wasi" ||
-                          target == "wasm32-unknown-wasi" ||
-                          target == "wasm32-unknown-unknown" {
+                } else if target == "wasm32-wasi"
+                    || target == "wasm32-unknown-wasi"
+                    || target == "wasm32-unknown-unknown"
+                {
                     "clang".to_string()
                 } else if target.contains("vxworks") {
                     "wr=c++".to_string()
@@ -2398,7 +2412,14 @@ fn fail(s: &str) -> ! {
     std::process::exit(1);
 }
 
-fn command_add_output_file(cmd: &mut Command, dst: &Path, cuda: bool, msvc: bool, is_asm: bool, is_arm: bool) {
+fn command_add_output_file(
+    cmd: &mut Command,
+    dst: &Path,
+    cuda: bool,
+    msvc: bool,
+    is_asm: bool,
+    is_arm: bool,
+) {
     if msvc && !cuda && !(is_asm && is_arm) {
         let mut s = OsString::from("-Fo");
         s.push(&dst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1220,15 +1220,9 @@ impl Build {
             ToolFamily::Msvc { clang_cl } => {
                 if clang_cl {
                     if target.contains("x86_64") {
-                        if self.cuda {
-                            cmd.args.push("-m64".into());
-                        }
-                        cmd.push_cc_arg("-m64".into());
+                        cmd.args.push("-m64".into());
                     } else if target.contains("86") {
-                        if self.cuda {
-                            cmd.args.push("-m32".into());
-                        }
-                        cmd.push_cc_arg("-m32".into());
+                        cmd.args.push("-m32".into());
                         cmd.push_cc_arg("/arch:IA32".into());
                     } else {
                         cmd.push_cc_arg(format!("--target={}", target).into());
@@ -1249,11 +1243,7 @@ impl Build {
                 // the SDK, but for all released versions of the
                 // Windows SDK it is required.
                 if target.contains("arm") || target.contains("thumb") {
-                    if self.cuda {
-                        cmd.args.push("-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1".into());
-                    } else {
-                        cmd.args.push("/D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1".into());
-                    }
+                    cmd.args.push("-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1".into());
                 }
             }
             ToolFamily::Gnu => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ impl Build {
 
         let mut cmd = compiler.to_command();
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(&mut cmd, &obj, target.contains("msvc"), false, is_arm);
+        command_add_output_file(&mut cmd, &obj, self.cuda, target.contains("msvc"), false, is_arm);
 
         // We need to explicitly tell msvc not to link and create an exe
         // in the root directory of the crate
@@ -973,7 +973,7 @@ impl Build {
             )
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(&mut cmd, &obj.dst, msvc, is_asm, is_arm);
+        command_add_output_file(&mut cmd, &obj.dst, self.cuda, msvc, is_asm, is_arm);
         // armasm and armasm64 don't requrie -c option
         if !msvc || !is_asm || !is_arm {
             cmd.arg("-c");
@@ -2398,8 +2398,8 @@ fn fail(s: &str) -> ! {
     std::process::exit(1);
 }
 
-fn command_add_output_file(cmd: &mut Command, dst: &Path, msvc: bool, is_asm: bool, is_arm: bool) {
-    if msvc && !(is_asm && is_arm) {
+fn command_add_output_file(cmd: &mut Command, dst: &Path, cuda: bool, msvc: bool, is_asm: bool, is_arm: bool) {
+    if msvc && !cuda && !(is_asm && is_arm) {
         let mut s = OsString::from("-Fo");
         s.push(&dst);
         cmd.arg(s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,13 +2399,7 @@ fn fail(s: &str) -> ! {
 }
 
 fn command_add_output_file(cmd: &mut Command, dst: &Path, cuda: bool, msvc: bool, is_asm: bool, is_arm: bool) {
-    if cuda {
-        cmd.arg("-o").arg(&dst);
-    } else if msvc && is_asm && is_arm {
-        cmd.arg("-o").arg(&dst);
-    } else if msvc && is_asm {
-        cmd.arg("-Fo").arg(dst);
-    } else if msvc {
+    if msvc && !(is_asm && is_arm) {
         let mut s = OsString::from("-Fo");
         s.push(&dst);
         cmd.arg(s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ impl Build {
 
         let mut cmd = compiler.to_command();
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(&mut cmd, &obj, self.cuda, target.contains("msvc"), false, is_arm);
+        command_add_output_file(&mut cmd, &obj, target.contains("msvc"), false, is_arm);
 
         // We need to explicitly tell msvc not to link and create an exe
         // in the root directory of the crate
@@ -973,7 +973,7 @@ impl Build {
             )
         };
         let is_arm = target.contains("aarch64") || target.contains("arm");
-        command_add_output_file(&mut cmd, &obj.dst, self.cuda, msvc, is_asm, is_arm);
+        command_add_output_file(&mut cmd, &obj.dst, msvc, is_asm, is_arm);
         // armasm and armasm64 don't requrie -c option
         if !msvc || !is_asm || !is_arm {
             cmd.arg("-c");
@@ -2398,7 +2398,7 @@ fn fail(s: &str) -> ! {
     std::process::exit(1);
 }
 
-fn command_add_output_file(cmd: &mut Command, dst: &Path, cuda: bool, msvc: bool, is_asm: bool, is_arm: bool) {
+fn command_add_output_file(cmd: &mut Command, dst: &Path, msvc: bool, is_asm: bool, is_arm: bool) {
     if msvc && !(is_asm && is_arm) {
         let mut s = OsString::from("-Fo");
         s.push(&dst);

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -180,8 +180,8 @@ mod impl_ {
     use std::ffi::OsString;
     use std::fs::File;
     use std::io::Read;
-    use std::mem;
     use std::iter;
+    use std::mem;
     use std::path::{Path, PathBuf};
 
     use Tool;
@@ -218,7 +218,7 @@ mod impl_ {
         }
     }
 
-    fn vs16_instances() -> Box<Iterator<Item=PathBuf>> {
+    fn vs16_instances() -> Box<Iterator<Item = PathBuf>> {
         let instances = if let Some(instances) = vs15_instances() {
             instances
         } else {
@@ -236,17 +236,19 @@ mod impl_ {
     }
 
     fn find_tool_in_vs16_path(tool: &str, target: &str) -> Option<Tool> {
-        vs16_instances().filter_map(|path| {
-            let path = path.join(tool);
-            if !path.is_file() {
-                return None;
-            }
-            let mut tool = Tool::new(path);
-            if target.contains("x86_64") {
-                tool.env.push(("Platform".into(), "X64".into()));
-            }
-            Some(tool)
-        }).next()
+        vs16_instances()
+            .filter_map(|path| {
+                let path = path.join(tool);
+                if !path.is_file() {
+                    return None;
+                }
+                let mut tool = Tool::new(path);
+                if target.contains("x86_64") {
+                    tool.env.push(("Platform".into(), "X64".into()));
+                }
+                Some(tool)
+            })
+            .next()
     }
 
     fn find_msbuild_vs16(target: &str) -> Option<Tool> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -290,11 +290,11 @@ fn msvc_smoke() {
     test.gcc().file("foo.c").compile("foo");
 
     test.cmd(0)
-        .must_have("/O2")
+        .must_have("-O2")
         .must_have("foo.c")
-        .must_not_have("/Z7")
-        .must_have("/c")
-        .must_have("/MD");
+        .must_not_have("-Z7")
+        .must_have("-c")
+        .must_have("-MD");
     test.cmd(1).must_have(test.td.path().join("foo.o"));
 }
 
@@ -303,14 +303,14 @@ fn msvc_opt_level_0() {
     let test = Test::msvc();
     test.gcc().opt_level(0).file("foo.c").compile("foo");
 
-    test.cmd(0).must_not_have("/O2");
+    test.cmd(0).must_not_have("-O2");
 }
 
 #[test]
 fn msvc_debug() {
     let test = Test::msvc();
     test.gcc().debug(true).file("foo.c").compile("foo");
-    test.cmd(0).must_have("/Z7");
+    test.cmd(0).must_have("-Z7");
 }
 
 #[test]
@@ -330,7 +330,7 @@ fn msvc_define() {
         .file("foo.c")
         .compile("foo");
 
-    test.cmd(0).must_have("/DFOO=bar").must_have("/DBAR");
+    test.cmd(0).must_have("-DFOO=bar").must_have("-DBAR");
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn msvc_static_crt() {
     let test = Test::msvc();
     test.gcc().static_crt(true).file("foo.c").compile("foo");
 
-    test.cmd(0).must_have("/MT");
+    test.cmd(0).must_have("-MT");
 }
 
 #[test]
@@ -346,5 +346,5 @@ fn msvc_no_static_crt() {
     let test = Test::msvc();
     test.gcc().static_crt(false).file("foo.c").compile("foo");
 
-    test.cmd(0).must_have("/MD");
+    test.cmd(0).must_have("-MD");
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -318,7 +318,7 @@ fn msvc_include() {
     let test = Test::msvc();
     test.gcc().include("foo/bar").file("foo.c").compile("foo");
 
-    test.cmd(0).must_have("/I").must_have("foo/bar");
+    test.cmd(0).must_have("-I").must_have("foo/bar");
 }
 
 #[test]


### PR DESCRIPTION
Tested building https://github.com/trolleyman/cuda-macros with this (the `cuda-macros-test` crate) and it builds & links correctly. Haven't had a chance to test that this runs yet, but will in the morning.

I wasn't sure that this way is the most elegant, but this seemed like the way that did the least amount of changes. I am also not sure that this is the correct way of doing this, especially regarding cross-compiling, but it gets it up and running at least.

To test you can do a `cargo build` in the root of the repo linked above. The build stuff is a bit hacky, but essentially it generates the CUDA function below & calls it.

```c
extern "C" __global__ void hello(int32_t* x, int32_t y) {
    printf("Hello from block %d, thread %d (y=%d)\n", blockIdx.x, threadIdx.x, y);
    *x = 2;
}
```

```rust
extern "C" unsafe fn hello(x: *mut i32, y: i32);
```