### PR TITLE
risc-v: Set ABI correctly for 32-bit targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1436,7 +1436,11 @@ impl Build {
                         cmd.args.push(("-march=rv".to_owned() + arch).into());
                         // ABI is always soft-float right now, update this when this is no longer the
                         // case:
-                        cmd.args.push("-mabi=lp64".into());
+                        if arch.starts_with("64") {
+                            cmd.args.push("-mabi=lp64".into());
+                        } else {
+                            cmd.args.push("-mabi=ilp32".into());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Pick the correct softfloat mode based on bitness:

- `-mabi=lp64` for 64 bit RISC-V (longs and pointers 64 bit, integers 32 bit, no fp registers)
- `-mabi=ilp32` for 32-bit RISC-V (integers, longs and pointers 32-bit, no fp registers)

Currently it fails for rv32 due to a conflict between the ABI and arch:

    cc1: error: ABI requires -march=rv64

ref: https://github.com/rust-lang/rust/issues/60012#issuecomment-483984475