### PR TITLE
risc-v: Disable PIC by default for now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,7 +824,7 @@ impl Build {
 
     /// Configures whether the compiler will emit position independent code.
     ///
-    /// This option defaults to `false` for `windows-gnu` targets and
+    /// This option defaults to `false` for `windows-gnu` and `riscv` targets and
     /// to `true` for all other targets.
     pub fn pic(&mut self, pic: bool) -> &mut Build {
         self.pic = Some(pic);
@@ -1225,7 +1225,8 @@ impl Build {
                     cmd.push_cc_arg("-ffunction-sections".into());
                     cmd.push_cc_arg("-fdata-sections".into());
                 }
-                if self.pic.unwrap_or(!target.contains("windows-gnu")) {
+                // Disable generation of PIC on RISC-V for now: rust-lld doesn't support this yet
+                if self.pic.unwrap_or(!target.contains("windows-gnu") && !target.contains("riscv")) {
                     cmd.push_cc_arg("-fPIC".into());
                     // PLT only applies if code is compiled with PIC support,
                     // and only for ELF targets.


### PR DESCRIPTION
Rust's linker cannot currently handle gcc's fPIC compilation units
for RISC-V targets:

      = note: rust-lld: error:
          .got section detected in the input files. Dynamic relocations are not
          supported. If you are linking to C code compiled using the `gcc` crate
          then modify your build script to compile the C code _without_ the
          -fPIC flag. See the documentation of the `gcc::Config.fpic` method for
          details.

So disable PIC by default for now for `riscv` targets.