### PR TITLE
use wr-c++ instead of vx-cxx

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1778,7 +1778,7 @@ impl Build {
                           target == "wasm32-unknown-unknown" {
                     "clang".to_string()
                 } else if target.contains("vxworks") {
-		    "vx-cxx".to_string()
+		    "wr-c++".to_string()
 		} else if self.get_host()? != target {
                     // CROSS_COMPILE is of the form: "arm-linux-gnueabi-"
                     let cc_env = self.getenv("CROSS_COMPILE");


### PR DESCRIPTION
We decide to use the name "wr-c++" for the compiler driver.