### PR TITLE
Detect and use `IPHONEOS_DEPLOYMENT_TARGET` for the `-mi*os-version-min` flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1627,16 +1627,19 @@ impl Build {
             }
         };
 
+        let min_version = std::env::var("IPHONEOS_DEPLOYMENT_TARGET")
+                .unwrap_or_else(|_| "7.0".into());
+
         let sdk = match arch {
             ArchSpec::Device(arch) => {
                 cmd.args.push("-arch".into());
                 cmd.args.push(arch.into());
-                cmd.args.push("-miphoneos-version-min=7.0".into());
+                cmd.args.push(format!("-miphoneos-version-min={}", min_version).into());
                 "iphoneos"
             }
             ArchSpec::Simulator(arch) => {
                 cmd.args.push(arch.into());
-                cmd.args.push("-mios-simulator-version-min=7.0".into());
+                cmd.args.push(format!("-mios-simulator-version-min={}", min_version).into());
                 "iphonesimulator"
             }
         };


### PR DESCRIPTION
...If it isn't set, fallback to the previous setting of `-miphoneos-version-min=7.0` for real devices and `mios-simulator-version-min=7.0` for simulators.

----

I realize this doesn't quite fulfill the request in #383 (defining a method on `Tool`), but it at least allows you to specify your targeted minimum version in what seems to be a conventional way (I'm not super familiar with building Xcode projects from the CLI). In my case, I'm using [`cmake-rs`](https://github.com/alexcrichton/cmake-rs) to build a C project, which uses cmake to build an iOS project, all for my Rust project, and this change allowed me to get that project building.

I'd really like to implement that method on `Tool`, but after a few days now I realize I won't have the time in the near future and don't want to let my changes go stale. I hope this is helpful...