### PR TITLE
Rejigger parallel compilation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ categories = ["development-tools::build-utils"]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies]
-rayon = { version = "1.0", optional = true }
+num_cpus = { version = "1.10", optional = true }
+jobserver = { version = "0.1.16", optional = true }
 
 [features]
-parallel = ["rayon"]
+parallel = ["num_cpus", "jobserver"]
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
       vmImage: ubuntu-16.04
     displayName: Minimum Rust (Linux)
     variables:
-      TOOLCHAIN: 1.16.0
+      TOOLCHAIN: 1.31.0
     steps:
       - template: ci/azure-install-rust.yml
       - script: cargo build
@@ -21,7 +21,7 @@ jobs:
       vmImage: vs2017-win2016
     displayName: Minimum Rust (Windows)
     variables:
-      TOOLCHAIN: 1.16.0
+      TOOLCHAIN: 1.31.0
     steps:
       - template: ci/azure-install-rust.yml
       - script: cargo build


### PR DESCRIPTION
This commit reimplements parallel compilation support with a few goals
in mind:

* Primarily the `jobserver` crate is now used to limit parallelism
  across build scripts
* The `rayon` crate is no longer used to ensure this is a pretty
  lightweight dependency crate.

It's hoped that after this bakes for a bit we may be able to turn this
on by default!