### PR TITLE
allow overriding frame pointer defaults

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -39,10 +39,40 @@ fn gnu_opt_level_s() {
 }
 
 #[test]
-fn gnu_debug() {
+fn gnu_debug_fp_auto() {
     let test = Test::gnu();
     test.gcc().debug(true).file("foo.c").compile("foo");
     test.cmd(0).must_have("-g");
+    test.cmd(0).must_have("-fno-omit-frame-pointer");
+}
+
+#[test]
+fn gnu_debug_fp() {
+    let test = Test::gnu();
+    test.gcc().debug(true).file("foo.c").compile("foo");
+    test.cmd(0).must_have("-g");
+    test.cmd(0).must_have("-fno-omit-frame-pointer");
+}
+
+#[test]
+fn gnu_debug_nofp() {
+    let test = Test::gnu();
+    test.gcc()
+        .debug(true)
+        .force_frame_pointer(false)
+        .file("foo.c")
+        .compile("foo");
+    test.cmd(0).must_have("-g");
+    test.cmd(0).must_not_have("-fno-omit-frame-pointer");
+
+    let test = Test::gnu();
+    test.gcc()
+        .force_frame_pointer(false)
+        .debug(true)
+        .file("foo.c")
+        .compile("foo");
+    test.cmd(0).must_have("-g");
+    test.cmd(0).must_not_have("-fno-omit-frame-pointer");
 }
 
 #[test]


### PR DESCRIPTION
When using a Cargo.toml such containing:
```[profile.release]
debug = true
```
cc-rs will automatically add -fno-omit-frame-pointer which affects code generation,
in my opinion there should be a way to enable debug info, without affecting the resulting code generation.

This patch attempts to do so, by only adding -fno-omit-frame-pointer if the target profile is debug
rather than if debuginfo is enabled.  I imagine it's somewhat debatable the right way to make this possible.