### PR TITLE
Enable -fPIC on non-bare-metal RISC-V

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1365,11 +1365,11 @@ impl Build {
                     cmd.push_cc_arg("-ffunction-sections".into());
                     cmd.push_cc_arg("-fdata-sections".into());
                 }
-                // Disable generation of PIC on RISC-V for now: rust-lld doesn't support this yet
-                if self
-                    .pic
-                    .unwrap_or(!target.contains("windows-gnu") && !target.contains("riscv"))
-                {
+                // Disable generation of PIC on bare-metal RISC-V for now: rust-lld doesn't support this yet
+                if self.pic.unwrap_or(
+                    !target.contains("windows-gnu")
+                        && !(target.contains("riscv") && target.contains("-none-")),
+                ) {
                     cmd.push_cc_arg("-fPIC".into());
                     // PLT only applies if code is compiled with PIC support,
                     // and only for ELF targets.


### PR DESCRIPTION
Rust default to position-independent executables so this is needed.