### PR TITLE
Implement std::error::Error for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,8 @@ impl Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 /// Configuration used to represent an invocation of a C compiler.
 ///
 /// This can be used to figure out what compiler is in use, what the arguments


### PR DESCRIPTION
Fixes #456.

Would it be possible to get a patch release when this lands? I have an upcoming project that would want to use the new impl. cc @KizzyCode