### PR TITLE
risc-v: Use medany model

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1421,6 +1421,7 @@ impl Build {
                         } else {
                             cmd.args.push("-mabi=ilp32".into());
                         }
+                        cmd.args.push("-mcmodel=medany".into());
                     }
                 }
             }


### PR DESCRIPTION
With rust-lang/rust#62281, rust compiles in `mcmodel=medium` mode for RISC-V which is equivalent to GCC medany. This prevents linker relocation errors when code is placed outside the range `-0x80000000..0x7ffffffff`.