### PR TITLE
Clear CFLAGS and CXXFLAGS before tests

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,8 +2,18 @@ use crate::support::Test;
 
 mod support;
 
+// Some tests check that a flag is *not* present.  These tests might fail if the flag is set in the
+// CFLAGS or CXXFLAGS environment variables.  This function clears the CFLAGS and CXXFLAGS
+// variables to make sure that the tests can run correctly.
+fn reset_env() {
+    std::env::set_var("CFLAGS", "");
+    std::env::set_var("CXXFLAGS", "");
+}
+
 #[test]
 fn gnu_smoke() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc().file("foo.c").compile("foo");
 
@@ -19,6 +29,8 @@ fn gnu_smoke() {
 
 #[test]
 fn gnu_opt_level_1() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc().opt_level(1).file("foo.c").compile("foo");
 
@@ -27,6 +39,8 @@ fn gnu_opt_level_1() {
 
 #[test]
 fn gnu_opt_level_s() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc().opt_level_str("s").file("foo.c").compile("foo");
 
@@ -56,6 +70,8 @@ fn gnu_debug_fp() {
 
 #[test]
 fn gnu_debug_nofp() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .debug(true)
@@ -100,6 +116,8 @@ fn gnu_warnings() {
 
 #[test]
 fn gnu_extra_warnings0() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .warnings(true)
@@ -113,6 +131,8 @@ fn gnu_extra_warnings0() {
 
 #[test]
 fn gnu_extra_warnings1() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .warnings(false)
@@ -126,6 +146,8 @@ fn gnu_extra_warnings1() {
 
 #[test]
 fn gnu_warnings_overridable() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .warnings(true)
@@ -154,6 +176,8 @@ fn gnu_x86_64() {
 
 #[test]
 fn gnu_x86_64_no_pic() {
+    reset_env();
+
     for vendor in &["unknown-linux-gnu", "apple-darwin"] {
         let target = format!("x86_64-{}", vendor);
         let test = Test::gnu();
@@ -215,6 +239,8 @@ fn gnu_x86_64_no_plt() {
 
 #[test]
 fn gnu_set_stdlib() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .cpp_set_stdlib(Some("foo"))
@@ -253,6 +279,8 @@ fn gnu_compile_assembly() {
 
 #[test]
 fn gnu_shared() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .file("foo.c")
@@ -265,6 +293,8 @@ fn gnu_shared() {
 
 #[test]
 fn gnu_flag_if_supported() {
+    reset_env();
+
     if cfg!(windows) {
         return;
     }
@@ -301,6 +331,8 @@ fn gnu_flag_if_supported_cpp() {
 
 #[test]
 fn gnu_static() {
+    reset_env();
+
     let test = Test::gnu();
     test.gcc()
         .file("foo.c")
@@ -313,6 +345,8 @@ fn gnu_static() {
 
 #[test]
 fn msvc_smoke() {
+    reset_env();
+
     let test = Test::msvc();
     test.gcc().file("foo.c").compile("foo");
 
@@ -327,6 +361,8 @@ fn msvc_smoke() {
 
 #[test]
 fn msvc_opt_level_0() {
+    reset_env();
+
     let test = Test::msvc();
     test.gcc().opt_level(0).file("foo.c").compile("foo");
 


### PR DESCRIPTION
Some test cases check that a compiler flag is not present.  But `cc::Build` loads additional flags from the `CFLAGS` and `CXXFLAGS` environment variables.  If these are set, they might interfere with the test cases.

Therefore this patch clears the `CFLAGS` and `CXXFLAGS` environment variables before running a test case that requires an absent flag.

----

This caused test failures in the Debian CI ([example log][]).  To reproduce the problem, run:

```
CFLAGS="-g -O2" CXXFLAGS="-stdlib=foo" cargo test
```

[example log]: https://ci.debian.net/data/autopkgtest/unstable/amd64/r/rust-cc/4083421/log.gz