### PR TITLE
Detect and use sccache by introspecting RUSTC_WRAPPER

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -22,6 +22,18 @@ pub struct Execution {
 
 impl Test {
     pub fn new() -> Test {
+        // This is ugly: `sccache` needs to introspect the compiler it is
+        // executing, as it adjusts its behavior depending on the
+        // language/compiler. This crate's test driver uses mock compilers that
+        // are obviously not supported by sccache, so the tests fail if
+        // RUSTC_WRAPPER is set. rust doesn't build test dependencies with
+        // the `test` feature enabled, so we can't conditionally disable the
+        // usage of `sccache` if running in a test environment, at least not
+        // without setting an environment variable here and testing for it
+        // there. Explicitly deasserting RUSTC_WRAPPER here seems to be the
+        // lesser of the two evils.
+        env::remove_var("RUSTC_WRAPPER");
+
         let mut gcc = PathBuf::from(env::current_exe().unwrap());
         gcc.pop();
         if gcc.ends_with("deps") {


### PR DESCRIPTION
If no other C/C++ caching tool is found by inspecting `CC` and `CXX`,
`RUSTC_WRAPPER` is tested to see if an output-caching wrapper for
`rustc` is in use. If that is the case and it is a wrapper known to also
support C/C++ caching, use it.