### PR TITLE
Add prefix autodetecting for 'armv5te-unknown-linux-musleabi' target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1994,6 +1994,7 @@ impl Build {
                         "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
                         "armv4t-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
                         "armv5te-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
+                        "armv5te-unknown-linux-musleabi" => Some("arm-linux-gnueabi"),
                         "arm-frc-linux-gnueabi" => Some("arm-frc-linux-gnueabi"),
                         "arm-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
                         "arm-unknown-linux-musleabi" => Some("arm-linux-musleabi"),


### PR DESCRIPTION
Rustup supports `armv5te-unknown-linux-musleabi` target but `cc-rs` can't autodetect the prefix of CLI tools (\*-gcc/\*-g++). This PR fixes it.