### PR TITLE
use "gcc" by default on illumos systems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1912,8 +1912,11 @@ impl Build {
             ("CC", "cl.exe", "gcc", "cc", "clang")
         };
 
-        // On Solaris, c++/cc unlikely to exist or be correct.
-        let default = if host.contains("solaris") {
+        // On historical Solaris systems, "cc" may have been Sun Studio, which
+        // is not flag-compatible with "gcc".  This history casts a long shadow,
+        // and many modern illumos distributions today ship GCC as "gcc" without
+        // also making it available as "cc".
+        let default = if host.contains("solaris") || host.contains("illumos") {
             gnu
         } else {
             traditional


### PR DESCRIPTION
Now that we have an illumos-specific host triple, we need to give it the same treatment that Solaris had with respect to compiler driver selection for now.  I have fleshed out the comment with a slightly more detailed explanation for the difference from other platforms.