### PR TITLE
Fix Android clang compiler path when building with Windows host

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1980,7 +1980,11 @@ impl Build {
                         .replace("thumbv7neon", "arm")
                         .replace("thumbv7", "arm");
                     let gnu_compiler = format!("{}-{}", target, gnu);
-                    let clang_compiler = format!("{}-{}", target, clang);
+                    let clang_compiler = if host.contains("windows") {
+                        format!("{}-{}.cmd", target, clang)
+                    } else {
+                        format!("{}-{}", target, clang)
+                    };
                     // Check if gnu compiler is present
                     // if not, use clang
                     if Command::new(&gnu_compiler).spawn().is_ok() {


### PR DESCRIPTION
On Windows, the Android NDK provides the `%ANDROID_TARGET%-clang` executable as a `.cmd` file rather than an `.exe` file. `std::process::Command` can only resolve `.exe` commands when the command extension isn't explicitly provided (see https://github.com/rust-lang/rust/issues/37519#issuecomment-390311261), so `cc-rs` mistakenly thinks the `%ANDROID_TARGET%-clang` compiler isn't installed on the system even when it's in the path. This PR fixes that.