### PR TITLE
In windows_registry::find_tool, set the ToolFamily to Msvc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2393,6 +2393,7 @@ impl Tool {
         Self::with_features(path, clang_driver, false)
     }
 
+    #[cfg(windows)]
     /// Explictly set the `ToolFamily`, skipping name-based detection.
     fn with_family(path: PathBuf, family: ToolFamily) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2393,6 +2393,20 @@ impl Tool {
         Self::with_features(path, clang_driver, false)
     }
 
+    /// Explictly set the `ToolFamily`, skipping name-based detection.
+    fn with_family(path: PathBuf, family: ToolFamily) -> Self {
+        Self {
+            path: path,
+            cc_wrapper_path: None,
+            cc_wrapper_args: Vec::new(),
+            args: Vec::new(),
+            env: Vec::new(),
+            family: family,
+            cuda: false,
+            removed_args: Vec::new(),
+        }
+    }
+
     fn with_features(path: PathBuf, clang_driver: Option<&str>, cuda: bool) -> Self {
         // Try to detect family of the tool from its name, falling back to Gnu.
         let family = if let Some(fname) = path.file_name().and_then(|p| p.to_str()) {

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -13,7 +13,9 @@
 
 use std::process::Command;
 
-use crate::{Tool, ToolFamily};
+use crate::Tool;
+#[cfg(windows)]
+use crate::ToolFamily;
 
 #[cfg(windows)]
 const MSVC_FAMILY: ToolFamily = ToolFamily::Msvc { clang_cl: false };

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -177,8 +177,8 @@ mod impl_ {
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
 
-    use crate::Tool;
     use super::MSVC_FAMILY;
+    use crate::Tool;
 
     struct MsvcTool {
         tool: PathBuf,

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -15,6 +15,7 @@ use std::process::Command;
 
 use crate::{Tool, ToolFamily};
 
+#[cfg(windows)]
 const MSVC_FAMILY: ToolFamily = ToolFamily::Msvc { clang_cl: false };
 
 /// Attempts to find a tool within an MSVC installation using the Windows


### PR DESCRIPTION
Ensures that the `Tool` returned from `windows_registry::find_tool` will always return true for `is_like_msvc()`. Addresses issue #498.