### PR TITLE
Support for Cuda Separate Compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -929,22 +929,6 @@ impl Build {
             objects.push(Object::new(file.to_path_buf(), obj));
         }
         self.compile_objects(&objects)?;
-
-        if self.cuda {
-            let compiler = self.try_get_compiler()?;
-            let mut cmd = compiler.to_command();
-            cmd.arg("-dlink");
-            for obj in objects.clone() {
-                cmd.arg(obj.dst);
-            }
-            cmd.arg("-o");
-            let out_dir = self.get_out_dir()?;
-            let out_dir = out_dir.join("link.o");
-            cmd.arg(out_dir);
-            println!("running {:?}", cmd);
-            run(&mut cmd, "nvcc")?;
-        }
-
         self.assemble(lib_name, &dst.join(gnu_lib_name), &objects)?;
 
         if self.get_target()?.contains("msvc") {
@@ -1155,6 +1139,21 @@ impl Build {
         for obj in objs {
             self.compile_object(obj)?;
         }
+
+        if self.cuda {
+            let compiler = self.try_get_compiler()?;
+            let mut cmd = compiler.to_command();
+            cmd.arg("-dlink");
+            for obj in objs {
+                cmd.arg(obj.dst.clone());
+            }
+            cmd.arg("-o");
+            let out_dir = self.get_out_dir()?;
+            let out_dir = out_dir.join("link.o");
+            cmd.arg(out_dir);
+            run(&mut cmd, "nvcc")?;
+        }
+
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -929,6 +929,22 @@ impl Build {
             objects.push(Object::new(file.to_path_buf(), obj));
         }
         self.compile_objects(&objects)?;
+
+        if self.cuda {
+            let compiler = self.try_get_compiler()?;
+            let mut cmd = compiler.to_command();
+            cmd.arg("-dlink");
+            for obj in objects.clone() {
+                cmd.arg(obj.dst);
+            }
+            cmd.arg("-o");
+            let out_dir = self.get_out_dir()?;
+            let out_dir = out_dir.join("link.o");
+            cmd.arg(out_dir);
+            println!("running {:?}", cmd);
+            run(&mut cmd, "nvcc")?;
+        }
+
         self.assemble(lib_name, &dst.join(gnu_lib_name), &objects)?;
 
         if self.get_target()?.contains("msvc") {
@@ -1165,6 +1181,11 @@ impl Build {
                     .into_owned(),
             )
         };
+
+        if self.cuda {
+            cmd.arg("-dc");
+        }
+
         let is_arm = target.contains("aarch64") || target.contains("arm");
         command_add_output_file(&mut cmd, &obj.dst, self.cuda, msvc, clang, is_asm, is_arm);
         // armasm and armasm64 don't requrie -c option
@@ -1713,7 +1734,15 @@ impl Build {
         // appends to it, which we don't want.
         let _ = fs::remove_file(&dst);
 
-        let objects: Vec<_> = objs.iter().map(|obj| obj.dst.clone()).collect();
+        let mut objects: Vec<_> = objs.iter().map(|obj| obj.dst.clone()).collect();
+
+        if self.cuda {
+            let out_dir = self.get_out_dir()?;
+            let out_dir = out_dir.join("link.o");
+            objects.push(out_dir);
+        }
+
+        let objects = objects;
         let target = self.get_target()?;
         if target.contains("msvc") {
             let (mut cmd, program) = self.get_ar()?;


### PR DESCRIPTION
related to #505

This PR change the code to support for cuda separate compilation.
https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#using-separate-compilation-in-cuda

Before change, cc-rs run these command

```
$ nvcc {some option} -o {out_dir}/a.o -c a.cu
$ nvcc {some option} -o {out_dir}/b.o -c b.cu
$ ar crs {out_dir}/libkernel.o.a {out_dir}/a.o {out_dir}/b.o
```

But, this command fail by unresolved extern function error.
To perform separate compilation, we need to compile with `-dc` option, and to link object file with `-dlink` option.

After change, cc-rs run these command

```
$ nvcc {some option} -dc -o {out_dir}/a.o -c a.cu
$ nvcc {some option} -dc -o {out_dir}/b.o -c b.cu
$ nvcc {some option} -dlink {out_dir}/a.o {out_dir}/b.o -o {out_dir}/link.o
$ ar crs {out_dir}/libkernel.o.a {out_dir}/a.o {out_dir}/b.o {out_dir}/link.o
```


## code

build.rs(we need `println!("cargo:rustc-link-lib=cudadevrt");` for separate compilation)
```rust
extern crate cc;

fn main() {
    cc::Build::new()
        .cuda(true)
        .file("a.cu")
        .file("b.cu")
        .compile("kernel.o");

    println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
    println!("cargo:rustc-link-lib=cudart");
    println!("cargo:rustc-link-lib=cudadevrt");
}
```

a.cu
```cpp
#include "b.h"

__device__ double a_func(double x) {
    return b_func(x) + 1;
}


extern "C" {
    __global__ void
    batch_a_func(
        const double* x, double* y
    ) {
        int i = threadIdx.x;

        y[i] = a_func(x[i]);
    }
}
```

b.cu
```cpp
#include "b.h"

__device__ double b_func(double x) {
    return x + 1;
}
```

b.h
```cpp
__device__ double b_func(double x);
```