### PR TITLE
Add the host architecture Windows 10 SDK bin directory to the PATH, not the target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,11 @@ jobs:
             rust: stable
             target: aarch64-apple-ios
             no_run: --no-run
+          - build: windows-aarch64
+            os: windows-latest
+            rust: stable
+            target: aarch64-pc-windows-msvc
+            no_run: --no-run
           - build: win32
             os: windows-2016
             rust: stable-i686-msvc

--- a/cc-test/src/aarch64.asm
+++ b/cc-test/src/aarch64.asm
@@ -1,0 +1,8 @@
+    AREA |.text|, CODE, READONLY
+    GLOBAL |asm|
+    ALIGN 4
+|asm| PROC
+    mov w0, #7
+    ret
+    ENDP
+    END

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -347,6 +347,7 @@ mod impl_ {
         };
 
         let mut tool = MsvcTool::new(tool_path);
+        tool.path.push(bin_path.clone());
         tool.path.push(host_dylib_path);
         tool.libs.push(lib_path);
         tool.include.push(include_path);
@@ -424,8 +425,15 @@ mod impl_ {
         let sub = lib_subdir(target)?;
         let (ucrt, ucrt_version) = get_ucrt_dir()?;
 
+        let host = match host_arch() {
+            X86 => "x86",
+            X86_64 => "x64",
+            AARCH64 => "arm64",
+            _ => return None,
+        };
+
         tool.path
-            .push(ucrt.join("bin").join(&ucrt_version).join(sub));
+            .push(ucrt.join("bin").join(&ucrt_version).join(host));
 
         let ucrt_include = ucrt.join("include").join(&ucrt_version);
         tool.include.push(ucrt_include.join("ucrt"));
@@ -434,7 +442,7 @@ mod impl_ {
         tool.libs.push(ucrt_lib.join("ucrt").join(sub));
 
         if let Some((sdk, version)) = get_sdk10_dir() {
-            tool.path.push(sdk.join("bin").join(sub));
+            tool.path.push(sdk.join("bin").join(host));
             let sdk_lib = sdk.join("lib").join(&version);
             tool.libs.push(sdk_lib.join("um").join(sub));
             let sdk_include = sdk.join("include").join(&version);
@@ -443,7 +451,7 @@ mod impl_ {
             tool.include.push(sdk_include.join("winrt"));
             tool.include.push(sdk_include.join("shared"));
         } else if let Some(sdk) = get_sdk81_dir() {
-            tool.path.push(sdk.join("bin").join(sub));
+            tool.path.push(sdk.join("bin").join(host));
             let sdk_lib = sdk.join("lib").join("winv6.3");
             tool.libs.push(sdk_lib.join("um").join(sub));
             let sdk_include = sdk.join("include");


### PR DESCRIPTION
Fixes failures during cross-compilation when the host cannot execute the target architecture Windows 10 SDK tools.