### PR TITLE
Add -nologo command-line option to Microsoft assembler.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1687,6 +1687,7 @@ impl Build {
             "ml.exe"
         };
         let mut cmd = windows_registry::find(&target, tool).unwrap_or_else(|| self.cmd(tool));
+        cmd.arg("-nologo"); // undocumented, yet working with armasm[64]
         for directory in self.include_directories.iter() {
             cmd.arg("-I").arg(directory);
         }


### PR DESCRIPTION
Hi,

I'd like to make a case for adding -nologo to Microsoft assembler command line. Trouble is that cargo treats the logo as warning, and worst part is that it's "sticky." "Sticky" in sense that once object files are generated and you re-run 'cargo build' for whatever different reason, it will keep showing the logo (multiple if assembler was invoked several times) tagged with "warning" without actually executing the assembler.

Cheers.