### PR TITLE
Always specify architecture for x86_64 / aarch64 Darwin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1465,6 +1465,16 @@ impl Build {
                     cmd.args.push("-m64".into());
                 }
 
+                if target.contains("darwin") {
+                    if target.contains("x86_64") {
+                        cmd.args.push("-arch".into());
+                        cmd.args.push("x86_64".into());
+                    } else if target.contains("aarch64") {
+                        cmd.args.push("-arch".into());
+                        cmd.args.push("arm64".into());
+                    }
+                }
+
                 if self.static_flag.is_none() {
                     let features = self
                         .getenv("CARGO_CFG_TARGET_FEATURE")


### PR DESCRIPTION
This has a few benefits. The first is that it's not required to
specify `CFLAGS_aarch64_apple_darwin='-arch arm64'` when
cross-compiling from x86_64 to aarch64 (or `-arch x86_64` the other
way around).

Another is that the `cc` frontend performs some snooping of the
process hierarchy — if any parent is running in the Rosetta emulation
layer, it will default to targeting x86_64. This means that running
`cc` on a Developer Transition Kit is likely to suddenly and magically
revert to x86_64 if any piece of the chain is emulated (`rustc`,
`cargo`, `rustup`, the shell, even the terminal emulator!).

It's likely that the `-m64` option is superfluous with these new
options, but I don't see any harm in it either.