### PR TITLE
Use emar instead of ar when building for wasm32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2226,7 +2226,7 @@ impl Build {
         let default_ar = "ar".to_string();
         let program = if target.contains("android") {
             format!("{}-ar", target.replace("armv7", "arm"))
-        } else if target.contains("emscripten") {
+        } else if target.contains("emscripten") || target.contains("wasm32") {
             // Windows use bat files so we have to be a bit more specific
             if cfg!(windows) {
                 let mut cmd = self.cmd("cmd");


### PR DESCRIPTION
Static libraries created by the `cc` crate fail to link in WASM projects with [an error](https://emscripten.org/docs/compiling/Building-Projects.html#troubleshooting):

> archive has no index; run ranlib to add one

This is due to use of native `ar` instead of WASM-aware `emar`.