### PR TITLE
Fix issues with compiling on other platforms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1412,12 +1412,14 @@ impl Build {
             family.add_force_frame_pointer(cmd);
         }
 
+        let host = self.get_host()?;
+
         // Target flags
         match cmd.family {
             ToolFamily::Clang => {
                 if !(target.contains("android")
                     && android_clang_compiler_uses_target_arg_internally(&cmd.path))
-                    && (target != self.get_host()?)
+                    && (target != host)
                 {
                     cmd.args.push(format!("--target={}", target).into());
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1417,6 +1417,7 @@ impl Build {
             ToolFamily::Clang => {
                 if !(target.contains("android")
                     && android_clang_compiler_uses_target_arg_internally(&cmd.path))
+                    && (target != self.get_host()?)
                 {
                     cmd.args.push(format!("--target={}", target).into());
                 }


### PR DESCRIPTION
`riscv64gc-unknown-linux-gnu` has this issue - `--target` will not work when compiling natively on RISC-V with Clang.