### PR TITLE
Detect standalone android compiler with regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ edition = "2018"
 
 [dependencies]
 jobserver = { version = "0.1.16", optional = true }
-regex = "1.3.9"
 
 [features]
 parallel = ["jobserver"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2018"
 
 [dependencies]
 jobserver = { version = "0.1.16", optional = true }
+regex = "1.3.9"
 
 [features]
 parallel = ["jobserver"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@
 #![allow(deprecated)]
 #![deny(missing_docs)]
 
-use regex::Regex;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -2840,8 +2839,15 @@ static NEW_STANDALONE_ANDROID_COMPILERS: [&str; 4] = [
 // So to construct proper command line check if
 // `--target` argument would be passed or not to clang
 fn android_clang_compiler_uses_target_arg_internally(clang_path: &Path) -> bool {
-    let re = Regex::new(r"^.*\d{2}-clang(\+\+)?$").unwrap();
-    re.is_match(clang_path.to_str().unwrap())
+    if let Some(filename) = clang_path.file_name() {
+        if let Some(filename_str) = filename.to_str() {
+            filename_str.contains("android")
+        } else {
+            false
+        }
+    } else {
+        false
+    }
 }
 
 #[test]


### PR DESCRIPTION
The version pushed in the PR #495 only detects minimal versions of the compiler so other standalone compilers such as "armv7a-linux-androideabiNN-clang" with NN != 16 will not be detected.

Detecting standalone compiler with regex is more generic.