### PR TITLE
Remove outdated notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ A simple library meant to be used as a build dependency with Cargo packages in
 order to build a set of C/C++ files into a static archive. This crate calls out
 to the most relevant compiler for a platform, for example using `cl` on MSVC.
 
-> **Note**: this crate was recently renamed from the `gcc` crate, so if you're
-> looking for the `gcc` crate you're in the right spot!
-
 ## Using cc-rs
 
 First, you'll want to both add a build script for your crate (`build.rs`) and


### PR DESCRIPTION
I think it's fair to say that the migration is complete:

https://lib.rs/crates/gcc/rev