### PR TITLE
Method to add multiple includes: build.includes(...)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,35 @@ impl Build {
         self
     }
 
+    /// Add multiple directories to the `-I` include path.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use std::path::Path;
+    /// # let condition = true;
+    /// #
+    /// let mut extra_dir = None;
+    /// if condition {
+    ///     extra_dir = Some(Path::new("/path/to"));
+    /// }
+    ///
+    /// cc::Build::new()
+    ///     .file("src/foo.c")
+    ///     .includes(extra_dir)
+    ///     .compile("foo");
+    /// ```
+    pub fn includes<P>(&mut self, dirs: P) -> &mut Build
+    where
+        P: IntoIterator,
+        P::Item: AsRef<Path>,
+    {
+        for dir in dirs {
+            self.include(dir);
+        }
+        self
+    }
+
     /// Specify a `-D` variable with an optional value.
     ///
     /// # Example


### PR DESCRIPTION
Closes #352.

This adds an `includes` method to call `include(...)` for each dir in an iterator, matching the `files` method from #205 which calls `file(...)` for each source file in an iterator.

My immediate use case for this involves a bunch of dirs that may or may not be selected (`Option<PathBuf>`) so that's what I put in the documentation, but any other iterator would work.