### PR TITLE
chore: exclude `.github` folder from publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ code.
 keywords = ["build-dependencies"]
 readme = "README.md"
 categories = ["development-tools::build-utils"]
-exclude = ["/.travis.yml", "/appveyor.yml"]
+exclude = ["/.github", "/.travis.yml", "/appveyor.yml"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
it's [currently published](https://docs.rs/crate/cc/1.0.61/source/) on crates.io