### PR TITLE
progressive linking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1784,21 +1784,7 @@ impl Build {
             .chain(self.objects.clone())
             .collect();
 
-        let chunk_size = if self.get_host()?.contains("msvc") {
-            let max_command_line_len = 1024 * 6;
-            let estimated_command_line_len =
-                objs.iter().map(|a| a.as_os_str().len()).sum::<usize>();
-            if estimated_command_line_len > max_command_line_len {
-                let average_chars = estimated_command_line_len / objs.len();
-                max_command_line_len / average_chars
-            } else {
-                objs.len()
-            }
-        } else {
-            objs.len()
-        };
-
-        for chunk in objs.chunks(chunk_size) {
+        for chunk in objs.chunks(100) {
             self.assemble_progressive(dst, chunk)?;
         }
 


### PR DESCRIPTION
Should fix both #547 and #496

* When building from `msvc`, linking is split into chunks based on the estimated command line length and the number of objects that need linking. If the estimated command line length doesn't exceed `1024 * 6` it will process all files in one go like before.
* On non `msvc` hosts, nothing has changed as the objects are not split into chunks.

All tests succeeded locally and as an additional test I've compiled the huge `physx` crate from `msvc` to both `msvc` and Android.