### PR TITLE
Switch from the `r` option on `ar` to `q`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1859,7 +1859,7 @@ impl Build {
             for flag in self.ar_flags.iter() {
                 ar.arg(flag);
             }
-            run(ar.arg("crs").arg(dst).args(objs), &cmd)?;
+            run(ar.arg("cqs").arg(dst).args(objs), &cmd)?;
         }
 
         Ok(())


### PR DESCRIPTION
The `r` option means "add the object while replacing it if it already
exists", while the `q` option says "always add to the end". We actually
want the latter of these due to how this crate works because we're
always building archives from scratch, and we always want all our
objects to go in the archive instead of trying to replace previous
versions.

This should fix a recent issue with #564 where previously if everything
was in one giant command line `ar` would append two files but now
afterwards with multiple invocations the second invocation may overwrite
files added in the first invocation.

Closes #568