### PR TITLE
Split `s` out of the `ar` invocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc"
-version = "1.0.64"
+version = "1.0.65"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cc-rs"


### PR DESCRIPTION
This commit splits out the `s` command from the `ar` invocation to
happen as part of a separate step after the archive is fully assembled.
Turns out #569 has an issue on Linux where `qs` implies `r` (??), so to
get the append-only behavior of `q` we need to omit the `s`.

Closes #568 (for real this time?)