### PR TITLE
Call clang directly when cross-compiling from Windows to Android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2120,7 +2120,7 @@ impl Build {
                 for version in 16..=23 {
                     if target.contains(&format!("i686-linux-android{}", version)) {
                         tool.args.push("-mstackrealign".into());
-                    }           
+                    }
                 }
 
                 Some(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2117,6 +2117,8 @@ impl Build {
                 tool.path.set_extension("exe");
                 tool.args.push(format!("--target={}", target).into());
 
+                // Additionally, shell scripts for target i686-linux-android versions 16 to 24
+                // pass the `mstackrealign` option so we do that here as well.
                 for version in 16..=23 {
                     if target.contains(&format!("i686-linux-android{}", version)) {
                         tool.args.push("-mstackrealign".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2125,7 +2125,7 @@ impl Build {
                         if version > 15 && version < 25 {
                             tool.args.push("-mstackrealign".into());
                         }
-                    }          
+                    }
                 }
             };
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2109,9 +2109,9 @@ impl Build {
         // `--target=` ourselves.
         if host.contains("windows") && android_clang_compiler_uses_target_arg_internally(&tool.path)
         {
-            let mut f = || -> Option<bool> {
-                let file_name = tool.path.file_name()?.to_str()?.to_owned();
-                let (target, clang) = file_name.split_at(file_name.rfind("-")?);
+            if let Some(path) = tool.path.file_name() {
+                let file_name = path.to_str().unwrap().to_owned();
+                let (target, clang) = file_name.split_at(file_name.rfind("-").unwrap());
 
                 tool.path.set_file_name(clang.trim_start_matches("-"));
                 tool.path.set_extension("exe");
@@ -2122,10 +2122,7 @@ impl Build {
                         tool.args.push("-mstackrealign".into());
                     }
                 }
-
-                Some(true)
             };
-            f();
         }
 
         // If we found `cl.exe` in our environment, the tool we're returning is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2121,11 +2121,11 @@ impl Build {
                 // pass the `mstackrealign` option so we do that here as well.
                 if target.contains("i686-linux-android") {
                     let (_, version) = target.split_at(target.rfind("d").unwrap() + 1);
-                    let version: u32 = version.parse().unwrap();
-
-                    if version > 15 && version < 25 {
-                        tool.args.push("-mstackrealign".into());
-                    }
+                    if let Ok(version) = version.parse::<u32>() {
+                        if version > 15 && version < 25 {
+                            tool.args.push("-mstackrealign".into());
+                        }
+                    }          
                 }
             };
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2116,6 +2116,13 @@ impl Build {
                 tool.path.set_file_name(clang.trim_start_matches("-"));
                 tool.path.set_extension("exe");
                 tool.args.push(format!("--target={}", target).into());
+
+                for version in 16..=23 {
+                    if target.contains(&format!("i686-linux-android{}", version)) {
+                        tool.args.push("-mstackrealign".into());
+                    }           
+                }
+
                 Some(true)
             };
             f();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2119,8 +2119,11 @@ impl Build {
 
                 // Additionally, shell scripts for target i686-linux-android versions 16 to 24
                 // pass the `mstackrealign` option so we do that here as well.
-                for version in 16..=23 {
-                    if target.contains(&format!("i686-linux-android{}", version)) {
+                if target.contains("i686-linux-android") {
+                    let (_, version) = target.split_at(target.rfind("d").unwrap() + 1);
+                    let version: u32 = version.parse().unwrap();
+
+                    if version > 15 && version < 25 {
                         tool.args.push("-mstackrealign".into());
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3029,9 +3029,6 @@ fn autodetect_android_compiler(target: &str, host: &str, gnu: &str, clang: &str)
     let gnu_compiler = format!("{}-{}", target, gnu);
     let clang_compiler = format!("{}-{}", target, clang);
 
-    println!("CLANG_COMPILER: {}", clang_compiler);
-    println!("TARGET: {}", target);
-
     // On Windows, the Android clang compiler is provided as a `.cmd` file instead
     // of a `.exe` file. `std::process::Command` won't run `.cmd` files unless the
     // `.cmd` is explicitly appended to the command name, so we do that here.


### PR DESCRIPTION
On Windows, the Android clang compiler is provided as a `.cmd` file instead of a `.exe` file. The `.cmd` file is spawned as a process and thus has a command-line limit of around 32000 characters, which you will most likely not reach. However, the `.cmd` launches the `clang.exe`, which results in a command-line limit of around 8200 characters, which larger projects with lots of include directories will easily reach.

As a fix, I've reintroduced response files when compiling from Windows to Android. 