### PR TITLE
Use clang when cross-compiling to iOS targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2044,6 +2044,8 @@ impl Build {
                     } else {
                         format!("{}.exe", gnu)
                     }
+                } else if target.contains("ios") {
+                    clang.to_string()
                 } else if target.contains("android") {
                     autodetect_android_compiler(&target, &host, gnu, clang)
                 } else if target.contains("cloudabi") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2044,7 +2044,7 @@ impl Build {
                     } else {
                         format!("{}.exe", gnu)
                     }
-                } else if target.contains("ios") {
+                } else if target.contains("apple-ios") {
                     clang.to_string()
                 } else if target.contains("android") {
                     autodetect_android_compiler(&target, &host, gnu, clang)


### PR DESCRIPTION
This change allows the target flags to be set correctly when building for Mac Catalyst.