### PR TITLE
Avoid checking for overly-broad "cl" substring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2645,11 +2645,7 @@ impl Tool {
         let family = if let Some(fname) = path.file_name().and_then(|p| p.to_str()) {
             if fname.contains("clang-cl") {
                 ToolFamily::Msvc { clang_cl: true }
-            } else if fname.contains("cl")
-                && !fname.contains("cloudabi")
-                && !fname.contains("uclibc")
-                && !fname.contains("clang")
-            {
+            } else if fname.ends_with("cl") || fname == "cl.exe" {
                 ToolFamily::Msvc { clang_cl: false }
             } else if fname.contains("clang") {
                 match clang_driver {


### PR DESCRIPTION
Microsoft’s compiler is apparently called "cl" on Linux and "cl.exe" on Windows.

This allows for instance `powerpcle` to be used in the triple, and avoid considering it’s running under a MSVC compiler.

This implements the suggestion by @alexcrichton here: https://github.com/alexcrichton/cc-rs/issues/574#issuecomment-748192661

Fixes #574.