### PR TITLE
Use GNU AR for illumos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2342,6 +2342,12 @@ impl Build {
                 Some(t) => return Ok((t, "lib.exe".to_string())),
                 None => "lib.exe".to_string(),
             }
+        } else if target.contains("illumos") {
+            // The default 'ar' on illumos uses a non-standard flags,
+            // but the OS comes bundled with a GNU-compatible variant.
+            //
+            // Use the GNU-variant to match other Unix systems.
+            "gar".to_string()
         } else if self.get_host()? != target {
             match self.prefix_for_target(&target) {
                 Some(p) => {


### PR DESCRIPTION
When building some crates that make use of `cc-rs` in their build scripts, I noticed that `cargo build` died when running on illumos targets.

Specifically, I saw the following output:

```
$ cargo build

...

cargo:warning=ar: one of [drqtpmx] must be specified

  exit code: 1

  --- stderr
```

When supplying the manual environment variable `AR=...`, I noticed this issue could be avoided. However, the default `ar` implementation on illumos (in `/usr/bin/ar`) continued to be incompatible.

This PR updates the default, meaning that `cargo build` should now "cleanly work" without additional environment variables, by utilizing the "GNU AR" binary bundled with illumos (at `/usr/bin/gar`) instead of the illlumos-specific one.

Tested this out by compiling [ring](https://github.com/briansmith/ring) for illumos - before this patch, it failed, raising the `ar` issue. After this patch, it builds successfully with no errors.