### PR TITLE
Added a track-dependencies feature to only recompile when needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,12 @@ edition = "2018"
 
 [dependencies]
 jobserver = { version = "0.1.16", optional = true }
+json = { version = "0.12", optional = true }
 
 [features]
+default = ["track-dependencies"]
 parallel = ["jobserver"]
+track-dependencies = ["json"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ jobserver = { version = "0.1.16", optional = true }
 json = { version = "0.12", optional = true }
 
 [features]
-default = ["track-dependencies"]
 parallel = ["jobserver"]
 track-dependencies = ["json"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,7 +997,7 @@ impl Build {
             }
 
             for dep in unique_deps {
-                println!("cargo:rerun-if-changed={}", dep);
+                self.print(fromat!("cargo:rerun-if-changed={}", dep));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1234,12 +1234,15 @@ impl Build {
         }
 
         #[cfg(feature = "track-dependencies")]
-        if !track_dependencies || track_dependencies::is_run_needed(&obj) {
+        if !track_dependencies || track_dependencies::is_run_needed(&obj, &cmd) {
             run(&mut cmd, &name)?;
         }
 
         #[cfg(not(feature = "track-dependencies"))]
         run(&mut cmd, &name)?;
+
+        #[cfg(feature = "track-dependencies")]
+        track_dependencies::emit_rerun_directives(&obj);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,7 +1210,7 @@ impl Build {
         let compiler = self.try_get_compiler()?;
         let clang = compiler.family == ToolFamily::Clang;
         #[cfg(feature = "track-dependencies")]
-        let track_dependencies = self.track_dependencies && msvc && !is_asm;
+        let track_dependencies = self.track_dependencies && !is_asm;
         let (mut cmd, name) = if msvc && is_asm {
             self.msvc_macro_assembler()?
         } else {
@@ -1232,8 +1232,14 @@ impl Build {
 
         #[cfg(feature = "track-dependencies")]
         if track_dependencies {
-            cmd.arg("-sourceDependencies");
-            cmd.arg(&obj.dst.with_extension("json"));
+            if msvc {
+                cmd.arg("-sourceDependencies");
+                cmd.arg(&obj.dst.with_extension("json"));
+            } else {
+                cmd.arg("-MD");
+                cmd.arg("-MF");
+                cmd.arg(&obj.dst.with_extension("dep"));
+            }
         }
 
         command_add_output_file(&mut cmd, &obj.dst, self.cuda, msvc, clang, is_asm, is_arm);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -981,23 +981,25 @@ impl Build {
         let msvc = self.get_target()?.contains("msvc");
 
         #[cfg(feature = "track-dependencies")]
-        if self.track_dependencies {
-            let mut unique_deps = std::collections::HashSet::new();
+        {
+            if self.track_dependencies {
+                let mut unique_deps = std::collections::HashSet::new();
 
-            for obj in &objects {
-                if !obj.dst.is_file() {
-                    panic!("Faild to build: {:?}", obj.dst);
-                }
+                for obj in &objects {
+                    if !obj.dst.is_file() {
+                        panic!("Faild to build: {:?}", obj.dst);
+                    }
 
-                if let Some(dependencies) = track_dependencies::get_dependencies(&obj, msvc) {
-                    for dep in dependencies {
-                        unique_deps.insert(dep);
+                    if let Some(dependencies) = track_dependencies::get_dependencies(&obj, msvc) {
+                        for dep in dependencies {
+                            unique_deps.insert(dep);
+                        }
                     }
                 }
-            }
 
-            for dep in unique_deps {
-                self.print(&format!("cargo:rerun-if-changed={}", dep));
+                for dep in unique_deps {
+                    self.print(&format!("cargo:rerun-if-changed={}", dep));
+                }
             }
         }
 
@@ -1249,14 +1251,16 @@ impl Build {
         let is_arm = target.contains("aarch64") || target.contains("arm");
 
         #[cfg(feature = "track-dependencies")]
-        if track_dependencies {
-            if msvc {
-                cmd.arg("-sourceDependencies");
-                cmd.arg(&obj.dst.with_extension("json"));
-            } else {
-                cmd.arg("-MD");
-                cmd.arg("-MF");
-                cmd.arg(&obj.dst.with_extension("dep"));
+        {
+            if track_dependencies {
+                if msvc {
+                    cmd.arg("-sourceDependencies");
+                    cmd.arg(&obj.dst.with_extension("json"));
+                } else {
+                    cmd.arg("-MD");
+                    cmd.arg("-MF");
+                    cmd.arg(&obj.dst.with_extension("dep"));
+                }
             }
         }
 
@@ -1271,8 +1275,10 @@ impl Build {
         }
 
         #[cfg(feature = "track-dependencies")]
-        if !track_dependencies || track_dependencies::is_run_needed(&obj, &cmd, msvc) {
-            run(&mut cmd, &name)?;
+        {
+            if !track_dependencies || track_dependencies::is_run_needed(&obj, &cmd, msvc) {
+                run(&mut cmd, &name)?;
+            }
         }
 
         #[cfg(not(feature = "track-dependencies"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,7 +997,7 @@ impl Build {
             }
 
             for dep in unique_deps {
-                self.print(fromat!("cargo:rerun-if-changed={}", dep));
+                self.print(&format!("cargo:rerun-if-changed={}", dep));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2967,6 +2967,9 @@ fn command_add_output_file(
     is_arm: bool,
 ) {
     if msvc && !clang && !cuda && !(is_asm && is_arm) {
+        cmd.arg("-sourceDependencies");
+        cmd.arg(&dst.with_extension("json"));
+
         let mut s = OsString::from("-Fo");
         s.push(&dst);
         cmd.arg(s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1120,6 +1120,13 @@ impl Build {
             server.acquire_raw()?;
         }
 
+        if error.load(SeqCst) {
+            return Err(Error {
+                kind: ErrorKind::ToolExecError,
+                message: "Compilation failed".to_string(),
+            });
+        }
+
         return Ok(());
 
         /// Shared state from the parent thread to the child thread. This
@@ -1337,8 +1344,6 @@ impl Build {
 
         if !no_defaults {
             self.add_default_flags(&mut cmd, &target, &opt_level)?;
-        } else {
-            println!("Info: default compiler flags are disabled");
         }
 
         for arg in envflags {
@@ -2899,7 +2904,6 @@ fn run(cmd: &mut Command, program: &str) -> Result<(), Error> {
         }
     };
     print.join().unwrap();
-    println!("{}", status);
 
     if status.success() {
         Ok(())
@@ -2953,7 +2957,7 @@ fn run_output(cmd: &mut Command, program: &str) -> Result<Vec<u8>, Error> {
 }
 
 fn spawn(cmd: &mut Command, program: &str) -> Result<(Child, JoinHandle<()>), Error> {
-    println!("running: {:?}", cmd);
+    println!("{:?}", cmd);
 
     // Capture the standard error coming from these programs, and write it out
     // with cargo:warning= prefixes. Note that this is a bit wonky to avoid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2941,7 +2941,6 @@ fn run_output(cmd: &mut Command, program: &str) -> Result<Vec<u8>, Error> {
         }
     };
     print.join().unwrap();
-    println!("{}", status);
 
     if status.success() {
         Ok(stdout)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -977,6 +977,12 @@ impl Build {
             objects.push(Object::new(file.to_path_buf(), obj));
         }
         self.compile_objects(&objects)?;
+
+        #[cfg(feature = "track-dependencies")]
+        for obj in &objects {
+            track_dependencies::emit_rerun_directives(obj);
+        }
+
         self.assemble(lib_name, &dst.join(gnu_lib_name), &objects)?;
 
         if self.get_target()?.contains("msvc") {
@@ -1240,9 +1246,6 @@ impl Build {
 
         #[cfg(not(feature = "track-dependencies"))]
         run(&mut cmd, &name)?;
-
-        #[cfg(feature = "track-dependencies")]
-        track_dependencies::emit_rerun_directives(&obj);
 
         Ok(())
     }

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -103,13 +103,13 @@ fn dependencies(obj: &Object) -> Option<Vec<String>> {
 }
 
 pub(crate) fn is_run_needed(obj: &Object, cmd: &Command) -> bool {
-    if !obj.dst.is_file() {
-        return true;
-    }
-
     match write_file_if_changed(obj.dst.with_extension("command"), &format!("{:?}", cmd)) {
         Ok(WriteFileStatus::NewContentsWriten) | Err(_) => return true,
         _ => (),
+    }
+
+    if !obj.dst.is_file() {
+        return true;
     }
 
     match dependencies(&obj) {

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -124,9 +124,10 @@ pub(crate) fn get_dependencies(obj: &Object, msvc: bool) -> Option<Vec<String>> 
 }
 
 pub(crate) fn is_run_needed(obj: &Object, cmd: &Command, msvc: bool) -> bool {
-    match write_file_if_changed(obj.dst.with_extension("command"), &format!("{:?}", cmd)) {
-        Ok(WriteFileStatus::NewContentsWriten) | Err(_) => return true,
-        _ => (),
+    if let Ok(WriteFileStatus::NewContentsWriten) | Err(_) =
+        write_file_if_changed(obj.dst.with_extension("command"), &format!("{:?}", cmd))
+    {
+        return true;
     }
 
     if !obj.dst.is_file() {

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -33,7 +33,6 @@ pub fn is_any_input_newer_then_output<P1: AsRef<Path>, P2: AsRef<Path>>(
     false
 }
 
-#[cfg(feature = "track-dependencies")]
 pub(crate) fn is_run_needed(obj: &Object) -> bool {
     let deps_info_path = obj.dst.with_extension("json");
 
@@ -75,9 +74,4 @@ pub(crate) fn is_run_needed(obj: &Object) -> bool {
             .filter_map(|v| v.as_str())
             .chain(iter::once(src_file)),
     )
-}
-
-#[cfg(not(feature = "track-dependencies"))]
-pub(crate) fn is_run_needed(obj: &Object) -> bool {
-    true
 }

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -1,0 +1,83 @@
+use std::{fs::File, iter, path::Path, time::SystemTime};
+
+use crate::Object;
+
+fn get_modified_time<P: AsRef<Path>>(p: P) -> Option<SystemTime> {
+    let f = File::open(p).ok()?;
+    let metadata = f.metadata().ok()?;
+    metadata.modified().ok()
+}
+
+pub fn is_any_input_newer_then_output<P1: AsRef<Path>, P2: AsRef<Path>>(
+    out_path: P1,
+    in_paths: impl IntoIterator<Item = P2>,
+) -> bool {
+    let out_time = get_modified_time(out_path.as_ref());
+
+    if out_time.is_none() {
+        return true;
+    }
+
+    for in_path in in_paths.into_iter() {
+        let in_time = get_modified_time(in_path.as_ref());
+
+        if in_time.is_none() {
+            return true;
+        }
+
+        if in_time.unwrap() >= out_time.unwrap() {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(feature = "track-dependencies")]
+pub(crate) fn is_run_needed(obj: &Object) -> bool {
+    let deps_info_path = obj.dst.with_extension("json");
+
+    if !deps_info_path.is_file() {
+        return true;
+    }
+
+    let deps_info = match std::fs::read_to_string(deps_info_path) {
+        Ok(res) => res,
+        Err(_) => return true,
+    };
+
+    let deps = match json::parse(&deps_info) {
+        Ok(res) => res,
+        Err(_) => return true,
+    };
+
+    if !deps.has_key("Data") {
+        return true;
+    }
+
+    let data = &deps["Data"];
+
+    if !data.has_key("Includes") {
+        return true;
+    }
+
+    let includes = &data["Includes"];
+
+    let src_file = match obj.src.to_str() {
+        Some(s) => s,
+        None => return true,
+    };
+
+    is_any_input_newer_then_output(
+        &obj.dst,
+        includes
+            .members()
+            .filter_map(|v| v.as_str())
+            .chain(iter::once(src_file)),
+    )
+}
+
+#[cfg(not(feature = "track-dependencies"))]
+pub(crate) fn is_run_needed(obj: &Object) -> bool {
+    true
+}

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -1,13 +1,12 @@
+use crate::Object;
 use std::{error::Error, fs, fs::File, iter, path::Path, process::Command, time::SystemTime};
 
-use crate::Object;
-
-pub enum WriteFileStatus {
+enum WriteFileStatus {
     NewContentsWriten,
     NoWrite,
 }
 
-pub fn write_file_if_changed<P: AsRef<Path>>(
+fn write_file_if_changed<P: AsRef<Path>>(
     path: P,
     content: &str,
 ) -> Result<WriteFileStatus, Box<dyn Error>> {
@@ -33,7 +32,7 @@ fn get_modified_time<P: AsRef<Path>>(p: P) -> Option<SystemTime> {
     metadata.modified().ok()
 }
 
-pub fn is_any_input_newer_then_output<P1: AsRef<Path>, P2: AsRef<Path>>(
+fn is_any_input_newer_then_output<P1: AsRef<Path>, P2: AsRef<Path>>(
     out_path: P1,
     in_paths: impl IntoIterator<Item = P2>,
 ) -> bool {
@@ -58,51 +57,73 @@ pub fn is_any_input_newer_then_output<P1: AsRef<Path>, P2: AsRef<Path>>(
     false
 }
 
-fn dependencies(obj: &Object) -> Option<Vec<String>> {
-    let deps_info_path = obj.dst.with_extension("json");
+pub(crate) fn get_dependencies(obj: &Object, msvc: bool) -> Option<Vec<String>> {
+    if msvc {
+        let deps_info_path = obj.dst.with_extension("json");
 
-    if !deps_info_path.is_file() {
-        return None;
+        if !deps_info_path.is_file() {
+            return None;
+        }
+
+        let deps_info = match std::fs::read_to_string(deps_info_path) {
+            Ok(res) => res,
+            Err(_) => return None,
+        };
+
+        let deps = match json::parse(&deps_info) {
+            Ok(res) => res,
+            Err(_) => return None,
+        };
+
+        if !deps.has_key("Data") {
+            return None;
+        }
+
+        let data = &deps["Data"];
+
+        if !data.has_key("Includes") {
+            return None;
+        }
+
+        let includes = &data["Includes"];
+
+        let src_file = match obj.src.to_str() {
+            Some(s) => s,
+            None => return None,
+        };
+
+        Some(
+            includes
+                .members()
+                .filter_map(|v| v.as_str())
+                .chain(iter::once(src_file))
+                .map(|s| s.to_string())
+                .collect(),
+        )
+    } else {
+        let deps_info_path = obj.dst.with_extension("dep");
+
+        if !deps_info_path.is_file() {
+            return None;
+        }
+
+        let deps_info = match std::fs::read_to_string(deps_info_path) {
+            Ok(res) => res,
+            Err(_) => return None,
+        };
+
+        Some(
+            deps_info
+                .replace("\\", "")
+                .split_whitespace()
+                .skip(1)
+                .map(|s| s.to_string())
+                .collect(),
+        )
     }
-
-    let deps_info = match std::fs::read_to_string(deps_info_path) {
-        Ok(res) => res,
-        Err(_) => return None,
-    };
-
-    let deps = match json::parse(&deps_info) {
-        Ok(res) => res,
-        Err(_) => return None,
-    };
-
-    if !deps.has_key("Data") {
-        return None;
-    }
-
-    let data = &deps["Data"];
-
-    if !data.has_key("Includes") {
-        return None;
-    }
-
-    let includes = &data["Includes"];
-
-    let src_file = match obj.src.to_str() {
-        Some(s) => s,
-        None => return None,
-    };
-
-    Some(
-        includes
-            .members()
-            .filter_map(|v| v.as_str())
-            .chain(iter::once(src_file))
-            .map(|s| s.to_string())
-            .collect(),
-    )
 }
 
-pub(crate) fn is_run_needed(obj: &Object, cmd: &Command) -> bool {
+pub(crate) fn is_run_needed(obj: &Object, cmd: &Command, msvc: bool) -> bool {
     match write_file_if_changed(obj.dst.with_extension("command"), &format!("{:?}", cmd)) {
         Ok(WriteFileStatus::NewContentsWriten) | Err(_) => return true,
         _ => (),
@@ -112,20 +133,8 @@ pub(crate) fn is_run_needed(obj: &Object, cmd: &Command) -> bool {
         return true;
     }
 
-    match dependencies(&obj) {
+    match get_dependencies(&obj, msvc) {
         Some(dependencies) => is_any_input_newer_then_output(&obj.dst, dependencies),
         None => true,
-    }
-}
-
-pub(crate) fn emit_rerun_directives(obj: &Object) {
-    if !obj.dst.is_file() {
-        panic!("Faild to build: {:?}", obj.dst);
-    }
-
-    if let Some(dependencies) = dependencies(&obj) {
-        for dep in dependencies {
-            println!("cargo:rerun-if-changed={}", dep);
-        }
     }
 }

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -1,6 +1,31 @@
-use std::{fs::File, iter, path::Path, time::SystemTime};
+use std::{error::Error, fs, fs::File, iter, path::Path, process::Command, time::SystemTime};
 
 use crate::Object;
+
+pub enum WriteFileStatus {
+    NewContentsWriten,
+    NoWrite,
+}
+
+pub fn write_file_if_changed<P: AsRef<Path>>(
+    path: P,
+    content: &str,
+) -> Result<WriteFileStatus, Box<dyn Error>> {
+    let s = match fs::read_to_string(path.as_ref()) {
+        Ok(s) => s,
+        Err(_) => {
+            fs::write(path.as_ref(), content)?;
+            return Ok(WriteFileStatus::NewContentsWriten);
+        }
+    };
+
+    if s != content {
+        fs::write(path.as_ref(), content)?;
+        return Ok(WriteFileStatus::NewContentsWriten);
+    }
+
+    Ok(WriteFileStatus::NoWrite)
+}
 
 fn get_modified_time<P: AsRef<Path>>(p: P) -> Option<SystemTime> {
     let f = File::open(p).ok()?;
@@ -33,45 +58,66 @@ pub fn is_any_input_newer_then_output<P1: AsRef<Path>, P2: AsRef<Path>>(
     false
 }
 
-pub(crate) fn is_run_needed(obj: &Object) -> bool {
+fn dependencies(obj: &Object) -> Option<Vec<String>> {
     let deps_info_path = obj.dst.with_extension("json");
 
     if !deps_info_path.is_file() {
-        return true;
+        return None;
     }
 
     let deps_info = match std::fs::read_to_string(deps_info_path) {
         Ok(res) => res,
-        Err(_) => return true,
+        Err(_) => return None,
     };
 
     let deps = match json::parse(&deps_info) {
         Ok(res) => res,
-        Err(_) => return true,
+        Err(_) => return None,
     };
 
     if !deps.has_key("Data") {
-        return true;
+        return None;
     }
 
     let data = &deps["Data"];
 
     if !data.has_key("Includes") {
-        return true;
+        return None;
     }
 
     let includes = &data["Includes"];
 
     let src_file = match obj.src.to_str() {
         Some(s) => s,
-        None => return true,
+        None => return None,
     };
 
-    is_any_input_newer_then_output(
-        &obj.dst,
+    Some(
         includes
             .members()
             .filter_map(|v| v.as_str())
-            .chain(iter::once(src_file)),
+            .chain(iter::once(src_file))
+            .map(|s| s.to_string())
+            .collect(),
     )
+}
+
+pub(crate) fn is_run_needed(obj: &Object, cmd: &Command) -> bool {
+    match write_file_if_changed(obj.dst.with_extension("command"), &format!("{:?}", cmd)) {
+        Ok(WriteFileStatus::NewContentsWriten) | Err(_) => return true,
+        _ => (),
+    }
+
+    match dependencies(&obj) {
+        Some(dependencies) => is_any_input_newer_then_output(&obj.dst, dependencies),
+        None => true,
+    }
+}
+
+pub(crate) fn emit_rerun_directives(obj: &Object) {
+    if let Some(dependencies) = dependencies(&obj) {
+        for dep in dependencies {
+            println!("cargo:rerun-if-changed={}", dep);
+        }
+    }
 }

--- a/src/track_dependencies.rs
+++ b/src/track_dependencies.rs
@@ -103,6 +103,10 @@ fn dependencies(obj: &Object) -> Option<Vec<String>> {
 }
 
 pub(crate) fn is_run_needed(obj: &Object, cmd: &Command) -> bool {
+    if !obj.dst.is_file() {
+        return true;
+    }
+
     match write_file_if_changed(obj.dst.with_extension("command"), &format!("{:?}", cmd)) {
         Ok(WriteFileStatus::NewContentsWriten) | Err(_) => return true,
         _ => (),
@@ -115,6 +119,10 @@ pub(crate) fn is_run_needed(obj: &Object, cmd: &Command) -> bool {
 }
 
 pub(crate) fn emit_rerun_directives(obj: &Object) {
+    if !obj.dst.is_file() {
+        panic!("Faild to build: {:?}", obj.dst);
+    }
+
     if let Some(dependencies) = dependencies(&obj) {
         for dep in dependencies {
             println!("cargo:rerun-if-changed={}", dep);


### PR DESCRIPTION
My motivation for this is that at work we have a fairly large mixed rust and cpp codebase that we would like to transition into building completely with cargo.

This pull request adds a feature that will tell the c compiler to emit dependency information for each file. Then on a subsequent build the timestamp of each of the dependent files are checked to see if any of them is newer then the object file, Only then is the compile redone.

If having json as an optional dependency is completely out of the question i can write a manual parser for the msvc dependency information format.

Additionally rerun directives are printed so that cargo can know if the build script wants to rerun.

I have tested this with msvc, clang and gcc.

I also removed some prints that made it hard for me to spot errors in my cpp files.

I also fixed a bug where if parallel build is active the build script would claim the build succeeded even if a object file failed to compile.

To be conservative i made the feature off by default even if the feature flag is on.

PS: Do you squash on merge or should i squash manually?