### PR TITLE
allow cachepot als alternative to sccache

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2204,13 +2204,13 @@ impl Build {
         // No explicit CC wrapper was detected, but check if RUSTC_WRAPPER
         // is defined and is a build accelerator that is compatible with
         // C/C++ compilers (e.g. sccache)
-        let valid_wrappers = ["sccache", "cachepot"];
+        const VALID_WRAPPERS: &[&'static str] = &["sccache", "cachepot"];
 
         let rustc_wrapper = std::env::var_os("RUSTC_WRAPPER")?;
         let wrapper_path = Path::new(&rustc_wrapper);
         let wrapper_stem = wrapper_path.file_stem()?;
 
-        if valid_wrappers.contains(&wrapper_stem.to_str()?) {
+        if VALID_WRAPPERS.contains(&wrapper_stem.to_str()?) {
             Some(rustc_wrapper.to_str()?.to_owned())
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2204,7 +2204,7 @@ impl Build {
         // No explicit CC wrapper was detected, but check if RUSTC_WRAPPER
         // is defined and is a build accelerator that is compatible with
         // C/C++ compilers (e.g. sccache)
-        let valid_wrappers = ["sccache"];
+        let valid_wrappers = ["sccache", "cachepot"];
 
         let rustc_wrapper = std::env::var_os("RUSTC_WRAPPER")?;
         let wrapper_path = Path::new(&rustc_wrapper);


### PR DESCRIPTION
`cachepot` will be a maintained fork with a different security paradigma than the original `sccache`, it will retain the ability to build C/C++ and other common toolchains, yet will use a different threat model and will rejuvenate a lot of the internals.

As such we would like to allow-list the name `cachepot` in the `cc` crate to retain the ability to build c dependencies.

https://github.com/paritytech/sccache/pull/50