### PR TITLE
Probe for ARM64 MSBuild

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -277,6 +277,9 @@ mod impl_ {
                 if target.contains("x86_64") {
                     tool.env.push(("Platform".into(), "X64".into()));
                 }
+                if target.contains("aarch64") {
+                    tool.env.push(("Platform".into(), "ARM64".into()));
+                }
                 Some(tool)
             })
             .next()
@@ -406,6 +409,9 @@ mod impl_ {
             let mut tool = Tool::with_family(path, MSVC_FAMILY);
             if target.contains("x86_64") {
                 tool.env.push(("Platform".into(), "X64".into()));
+            }
+            if target.contains("aarch64") {
+                tool.env.push(("Platform".into(), "ARM64".into()));
             }
             tool
         })
@@ -810,10 +816,12 @@ mod impl_ {
             "16.0" => {
                 find_msbuild_vs16("x86_64-pc-windows-msvc").is_some()
                     || find_msbuild_vs16("i686-pc-windows-msvc").is_some()
+                    || find_msbuild_vs16("aarch64-pc-windows-msvc").is_some()
             }
             "15.0" => {
                 find_msbuild_vs15("x86_64-pc-windows-msvc").is_some()
                     || find_msbuild_vs15("i686-pc-windows-msvc").is_some()
+                    || find_msbuild_vs15("aarch64-pc-windows-msvc").is_some()
             }
             "12.0" | "14.0" => LOCAL_MACHINE
                 .open(&OsString::from(format!(


### PR DESCRIPTION
I found an interesting corner case. I've been installing a x86/x64 MSVC toolchain alongside an ARM64 toolchain, and I never had any problem detecting Visual Studio version. But when I uninstalled the x86/x64 MSVC toolchain, suddenly my test app stopped detecting Visual Studio.

I realized that cc-rs probes for MSBuild using different triples. This list of triples does include both i686 and x86_64, but it doesn't include aarch64. So I've added it to the list.

Additionally, I also now set MSBuild Platform property to ARM64 for aarch64 targets. I'm not 100% sure what does it affect, but looking at x86_64 I thought it might be a good idea.