### PR TITLE
Use riscv64-unknown-linux-gnu for target on clang.

### DIFF
--- a/cc-test/src/riscv64gc.S
+++ b/cc-test/src/riscv64gc.S
@@ -1,0 +1,9 @@
+.globl asm
+asm:
+    li a0, 7
+    ret
+
+.globl _asm
+_asm:
+    li a0, 7
+    ret

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1484,6 +1484,10 @@ impl Build {
                                 .into(),
                             );
                         }
+                    } else if target.starts_with("riscv64gc-") {
+                        cmd.args.push(
+                            format!("--target={}", target.replace("riscv64gc", "riscv64")).into(),
+                        );
                     } else {
                         cmd.args.push(format!("--target={}", target).into());
                     }


### PR DESCRIPTION
When using `CC=clang`, clang says `error: unknown target triple 'riscv64gc-unknown-linux-gnu'`. So we should replace `riscv64gc` with `riscv64`.