### PR TITLE
Address issues with new Catalyst/M1 simulator targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1535,9 +1535,19 @@ impl Build {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
-                            let ios = if arch == "arm64" { "ios" } else { "ios13.0" };
-                            cmd.args
-                                .push(format!("--target={}-apple-{}-macabi", arch, ios).into());
+                            let deployment_target = env::var("CATALYST_DEPLOYMENT_TARGET")
+                                .unwrap_or_else(|_| {
+                                    if arch == "arm64" {
+                                        "".into()
+                                    } else {
+                                        "13.0".into()
+                                    }
+                                });
+
+                            cmd.args.push(
+                                format!("--target={}-apple-ios{}-macabi", arch, deployment_target)
+                                    .into(),
+                            );
                         }
                     } else if target.contains("ios-sim") {
                         if let Some(arch) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1999,6 +1999,11 @@ impl Build {
             None => false,
         };
 
+        let is_sim = match target.split('-').nth(3) {
+            Some(v) => v == "sim",
+            None => false,
+        };
+
         let arch = if is_catalyst {
             match arch {
                 "arm64e" => ArchSpec::Catalyst("arm64e"),
@@ -2008,6 +2013,16 @@ impl Build {
                     return Err(Error::new(
                         ErrorKind::ArchitectureInvalid,
                         "Unknown architecture for iOS target.",
+                    ));
+                }
+            }
+        } else if is_sim {
+            match arch {
+                "arm64" | "aarch64" => ArchSpec::Simulator("-arch arm64"),
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::ArchitectureInvalid,
+                        "Unknown architecture for iOS simulator target.",
                     ));
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1535,19 +1535,8 @@ impl Build {
                         if let Some(arch) =
                             map_darwin_target_from_rust_to_compiler_architecture(target)
                         {
-                            let deployment_target = env::var("CATALYST_DEPLOYMENT_TARGET")
-                                .unwrap_or_else(|_| {
-                                    if arch == "arm64" {
-                                        "".into()
-                                    } else {
-                                        "13.0".into()
-                                    }
-                                });
-
-                            cmd.args.push(
-                                format!("--target={}-apple-ios{}-macabi", arch, deployment_target)
-                                    .into(),
-                            );
+                            cmd.args
+                                .push(format!("--target={}-apple-ios13.0-macabi", arch).into());
                         }
                     } else if target.contains("ios-sim") {
                         if let Some(arch) =


### PR DESCRIPTION
Hello!

With the introduction of the new M1 ARM computers, the target `aarch64-apple-ios` became somewhat ambiguous.
Before the ARM laptops, building for an ARM iOS target would indicate real hardware (e.g. iPhone), since simulators were only for x86 targets. However, when the M1 got introduced, there is now an ARM iOS simulator, that is different from real hardware. To handle this, there now exists a new build target `aarch64-apple-ios-sim`, that indicates simulator build.

This PR adds support for that, allowing one to build for `aarch64-apple-ios-sim` and having that result in the correct compiler flags (`-mios-simulator-version-min`).

Additionally, it adds support for addressing an issue I ran into in https://github.com/alexcrichton/cc-rs/pull/556#issuecomment-902133079
Similarly to `ios-sim` targets, the new Catalyst `macabi` targets benefits from having the ability to specify the SDK version.

Thanks!