### PR TITLE
Prefer cfg(target_feature = "crt-static") over CARGO_CFG_TARGET_FEATURE variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1447,10 +1447,7 @@ impl Build {
                     Some(true) => "-MT",
                     Some(false) => "-MD",
                     None => {
-                        let features = self
-                            .getenv("CARGO_CFG_TARGET_FEATURE")
-                            .unwrap_or(String::new());
-                        if features.contains("crt-static") {
+                        if self.get_crt_static_feature() {
                             "-MT"
                         } else {
                             "-MD"
@@ -1613,13 +1610,8 @@ impl Build {
                     }
                 }
 
-                if self.static_flag.is_none() {
-                    let features = self
-                        .getenv("CARGO_CFG_TARGET_FEATURE")
-                        .unwrap_or(String::new());
-                    if features.contains("crt-static") {
-                        cmd.args.push("-static".into());
-                    }
+                if self.static_flag.is_none() && self.get_crt_static_feature() {
+                    cmd.args.push("-static".into());
                 }
 
                 // armv7 targets get to use armv7 instructions
@@ -2673,6 +2665,18 @@ impl Build {
                 &format!("Environment variable {} not defined.", v.to_string()),
             )),
         }
+    }
+
+    #[cfg(target_feature = "crt-static")]
+    fn get_crt_static_feature(&self) -> bool {
+        true
+    }
+
+    #[cfg(not(target_feature = "crt-static"))]
+    fn get_crt_static_feature(&self) -> bool {
+        self.getenv("CARGO_CFG_TARGET_FEATURE")
+            .unwrap_or(String::new())
+            .contains("crt-static")
     }
 
     fn print(&self, s: &str) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -350,12 +350,18 @@ fn msvc_smoke() {
     let test = Test::msvc();
     test.gcc().file("foo.c").compile("foo");
 
-    test.cmd(0)
+    let execution = test.cmd(0);
+    execution
         .must_have("-O2")
         .must_have("foo.c")
         .must_not_have("-Z7")
-        .must_have("-c")
-        .must_have("-MD");
+        .must_have("-c");
+
+    #[cfg(target_feature = "crt-static")]
+    execution.must_have("-MT");
+    #[cfg(not(target_feature = "crt-static"))]
+    execution.must_have("-MD");
+
     test.cmd(1).must_have(test.td.path().join("foo.o"));
 }
 


### PR DESCRIPTION
This is a fix for a bug I found using `cxx` and reported there: https://github.com/dtolnay/cxx/issues/929. It may be a workaround for a bug in `cargo` itself, I'm not sure.

If you use `.cargo/config.toml` to add the `crt-static` target feature like so, `cargo` applies it to the `rustc` command line and it applies to the `cfg`, but it is not updating the `CARGO_CFG_TARGET_FEATURE` environment variable to reflect that:
```toml
[target.'cfg(target_env = "msvc")']
rustflags = ["-C", "target-feature=+crt-static"]
```

As a result, since this crate only checks the environment variable, the default value of `Build::static_crt` is wrong if you add the target feature this way. I think the `cfg` option should always take precedence since that's what determines how `cargo` will invoke `rustc` for any files that would be linked with files compiled using `cc`. If it's not specified, I left in conditionally compiled tests for the environment variable, so if there are packages/builds depending on that they should continue to work.