### PR TITLE
Adds cachepot to the known wrappers set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2370,7 +2370,7 @@ impl Build {
         //
         // It's true that everything here is a bit of a pain, but apparently if
         // you're not literally make or bash then you get a lot of bug reports.
-        let known_wrappers = ["ccache", "distcc", "sccache", "icecc"];
+        let known_wrappers = ["ccache", "distcc", "sccache", "icecc", "cachepot"];
 
         let mut parts = tool.split_whitespace();
         let maybe_wrapper = match parts.next() {


### PR DESCRIPTION
#599 missed this small change which leads to broken builds with `cachepot` as in paritytech/cachepot#107