### PR TITLE
Fix armhf build for GCC-11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1638,6 +1638,11 @@ impl Build {
                     && (target.contains("-linux-") || target.contains("-kmc-solid_"))
                 {
                     cmd.args.push("-march=armv7-a".into());
+
+                    if target.ends_with("eabihf") {
+                        // lowest common denominator FPU
+                        cmd.args.push("-mfpu=vfpv3-d16".into());
+                    }
                 }
 
                 // (x86 Android doesn't say "eabi")


### PR DESCRIPTION
GCC 11 changed the default flag to put the FP option in the -march flag (arm7-a+fp) rather than a specific FPU flag. Therefore it needs to be given separately now.

See https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1939379 for some more details.

Example build failure is here: https://buildd.debian.org/status/fetch.php?pkg=rustc&arch=armhf&ver=1.55.0%2Bdfsg1-1&stamp=1634161880&raw=0