### PR TITLE
fix: find_msvc_environment argument order

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -223,7 +223,7 @@ mod impl_ {
     }
 
     /// Attempt to find the tool using environment variables set by vcvars.
-    pub fn find_msvc_environment(target: &str, tool: &str) -> Option<Tool> {
+    pub fn find_msvc_environment(tool: &str, target: &str) -> Option<Tool> {
         // Early return if the environment doesn't contain a VC install.
         if env::var_os("VCINSTALLDIR").is_none() {
             return None;


### PR DESCRIPTION
According to the call from https://github.com/alexcrichton/cc-rs/blob/b2f6b146b75299c444e05bbde50d03705c7c4b6e/src/windows_registry.rs#L74-L79, the argument order is wrong

