### PR TITLE
Use riscv32-unknown-linux-gnu for target on clang

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1557,6 +1557,10 @@ impl Build {
                         cmd.args.push(
                             format!("--target={}", target.replace("riscv64gc", "riscv64")).into(),
                         );
+                    } else if target.starts_with("riscv32gc-") {
+                        cmd.args.push(
+                            format!("--target={}", target.replace("riscv32gc", "riscv32")).into(),
+                        );
                     } else if target.contains("uefi") {
                         if target.contains("x86_64") {
                             cmd.args.push("--target=x86_64-unknown-windows-gnu".into());


### PR DESCRIPTION
`riscv32gc-unknown-linux-gnu` (tier3) on `clang` has the same issue as https://github.com/alexcrichton/cc-rs/pull/608.

```
error: unknown target triple 'riscv32gc-unknown-linux-gnu', please use -triple or -arch
```