### PR TITLE
Fix cross-compilation from macOS using x86_64-elf-gcc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1619,8 +1619,15 @@ impl Build {
                 if target.contains("darwin") {
                     if let Some(arch) = map_darwin_target_from_rust_to_compiler_architecture(target)
                     {
-                        cmd.args.push("-arch".into());
-                        cmd.args.push(arch.into());
+                        let is_target_arch_specific_compiler = cmd
+                            .path
+                            .file_name()
+                            .and_then(|f| f.to_str())
+                            .map_or(false, |f| f.starts_with(arch));
+                        if !is_target_arch_specific_compiler {
+                            cmd.args.push("-arch".into());
+                            cmd.args.push(arch.into());
+                        }
                     }
                 }
 


### PR DESCRIPTION
This avoids setting `-arch` flag if the compiler already has name of the architecture in the file name, assuming it's already a compiler for only the desired architecture.

Fixes #633