### PR TITLE
Added arbitrary flag support to try_expand()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl Build {
         self
     }
 
-    /// Add an arbitrary flag to the invocation of the compiler
+    /// Add a flag to the invocation of the ar
     ///
     /// # Example
     ///
@@ -419,7 +419,6 @@ impl Build {
     ///     .ar_flag("/NODEFAULTLIB:libc.dll")
     ///     .compile("foo");
     /// ```
-
     pub fn ar_flag(&mut self, flag: &str) -> &mut Build {
         self.ar_flags.push(flag.to_string());
         self
@@ -1292,7 +1291,7 @@ impl Build {
         }
         cmd.arg("-E");
 
-        for flag in self.ar_flags.iter() {
+        for flag in self.flags.iter() {
             cmd.arg(flag);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1292,6 +1292,10 @@ impl Build {
         }
         cmd.arg("-E");
 
+        for flag in self.ar_flags.iter() {
+            cmd.arg(flag);
+        }
+
         assert!(
             self.files.len() <= 1,
             "Expand may only be called for a single file"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1291,10 +1291,6 @@ impl Build {
         }
         cmd.arg("-E");
 
-        for flag in self.flags.iter() {
-            cmd.arg(flag);
-        }
-
         assert!(
             self.files.len() <= 1,
             "Expand may only be called for a single file"


### PR DESCRIPTION
It's needed to pass macOS specific flags. For example: -F/Library/Frameworks.