### PR TITLE
Support riscv64-unknown-openbsd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1790,6 +1790,9 @@ impl Build {
                         } else if target.contains("freebsd") && arch.starts_with("64") {
                             cmd.args.push(("-march=rv64gc").into());
                             cmd.args.push("-mabi=lp64d".into());
+                        } else if target.contains("openbsd") && arch.starts_with("64") {
+                            cmd.args.push(("-march=rv64gc").into());
+                            cmd.args.push("-mabi=lp64d".into());
                         } else if target.contains("linux") && arch.starts_with("32") {
                             cmd.args.push(("-march=rv32gc").into());
                             cmd.args.push("-mabi=ilp32d".into());


### PR DESCRIPTION
it adds support for properly target riscv64-unknown-openbsd.