### PR TITLE
add linker for aarch64-apple-darwin target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-apple-darwin]
+linker = "/usr/bin/cc"


### PR DESCRIPTION
fix build failure on apple silicon ship by using [cc](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) instead default clang toolchain.